### PR TITLE
fix: Don't remove live sessions during agent startup / Small fixes

### DIFF
--- a/packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository.ts
+++ b/packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository.ts
@@ -84,7 +84,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
     try {
       // Initialize the database
       await this.buildPgDatabase()
-      this.logger?.info('[initialize] The database has been build successfully')
+      this.logger?.info('[initialize] The database has been built successfully')
 
       // Configure PostgreSQL pool for the messages collections
       this.messagesCollection = new Pool({
@@ -479,10 +479,6 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
           await dbClient.query(createTableLive)
           await dbClient.query(liveSessionTableIndex)
           this.logger?.info(`[buildPgDatabase] PostgresDbService Table "${liveSessionTableName}" created.`)
-        } else {
-          // If the table exists, clean it (truncate or delete, depending on your requirements).
-          await dbClient.query(`TRUNCATE TABLE ${liveSessionTableName}`)
-          this.logger?.info(`[buildPgDatabase] PostgresDbService Table "${liveSessionTableName}" cleared.`)
         }
 
         // Unlock after table creation
@@ -585,7 +581,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
         `INSERT INTO ${liveSessionTableName} (session_id, connection_id, protocol_version, instance) VALUES($1, $2, $3, $4) RETURNING session_id`,
         [id, connectionId, protocolVersion, instance]
       )
-      const liveSessionId = insertMessageDB?.rows[0].sessionid
+      const liveSessionId = insertMessageDB?.rows[0].session_id
       this.logger?.debug(`[addLiveSessionOnDb] add liveSession to ${connectionId} and result ${liveSessionId}`)
     } catch (error) {
       this.logger?.debug(`[addLiveSessionOnDb] error add liveSession DB ${connectionId}`)


### PR DESCRIPTION
This was discussed before but never made it to main branch. 

Removing the stored live sessions from the DB when starting up an agent prevents QueueAndLiveMode from scaling up instances, because a new instance will remove the live sessions even if they are active on another instance.

Possibly live instances can build up if not actually closed correctly, but I have not seen that behavior during testing. In any case cleaning zombie live session from the DB would be a separate feature.

Also fixes a tiny spelling mistake and using the wrong row name for a logging variable.