### PR TITLE
fix: Don't load pickup when PICKUP_TYPE is blank string

### DIFF
--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -92,7 +92,7 @@ export async function createAgent() {
 
   // Load the message pickup repository if configured
   let messagePickupRepository = undefined
-  if (config.get('agent:pickup').type !== undefined) {
+  if (config.get('agent:pickup').type) {
     logger.info(`Loading ${config.get('agent:pickup').type} pickup protocol`)
     messagePickupRepository = await loadPickup(config.get('agent:pickup').type, config.get('agent:pickup').strategy)
   }


### PR DESCRIPTION
This only work when the env variable was unset, not a blank string like the default helm chart value.