### PR TITLE
fix: Firebase credential parsing

### DIFF
--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -14,7 +14,9 @@ export const firebase: admin.app.App | undefined = !config.get('agent:usePushNot
         credential: admin.credential.cert({
           projectId: config.get('agent:firebase:projectId'),
           clientEmail: config.get('agent:firebase:clientEmail'),
-          privateKey: config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n'),
+          privateKey: config.get('agent:firebase:privateKey')?.includes('\\n')
+            ? config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n')
+            : config.get('agent:firebase:privateKey')?.trim(),
         }),
       })
 


### PR DESCRIPTION
When testing the firebase feature in an openshift deployment with a secret, I discovered that the private key environment variable used in the credential no longer has the new lines. When the mediator gets a credential in this format it should simply parse any white space and use as is.