### PR TITLE
feat(push-notifications): FCM setDeviceInfo and getDeviceInfo

### DIFF
--- a/.changeset/four-nails-cross.md
+++ b/.changeset/four-nails-cross.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/didcomm-push-notifications": patch
+---
+
+feat(push-notifications): add setDeviceInfo and getDeviceInfo to FCM API

--- a/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
+++ b/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
@@ -59,7 +59,7 @@ export class DidCommPushNotificationsFcmApi {
 
     const outbound = new DidCommOutboundMessageContext(message, {
       agentContext: this.agentContext,
-      connection: connection,
+      connection,
     })
     await this.messageSender.sendMessage(outbound)
   }
@@ -82,7 +82,7 @@ export class DidCommPushNotificationsFcmApi {
 
     const outbound = new DidCommOutboundMessageContext(message, {
       agentContext: this.agentContext,
-      connection: connection,
+      connection,
     })
     await this.messageSender.sendMessage(outbound)
   }
@@ -102,7 +102,7 @@ export class DidCommPushNotificationsFcmApi {
 
     const outbound = new DidCommOutboundMessageContext(message, {
       agentContext: this.agentContext,
-      connection: connection,
+      connection,
     })
     await this.messageSender.sendMessage(outbound)
   }

--- a/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
+++ b/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
@@ -41,14 +41,14 @@ export class DidCommPushNotificationsFcmApi {
       ])
   }
 
- /**
+  /**
    * Sends a set request with the fcm device info (token) to another agent via a `connectionId`
    *
    * @param connectionId The connection ID string
    * @param deviceInfo The FCM device info
    * @returns Promise<void>
    */
-  public async setDeviceInfo(options: { connectionId: string, deviceInfo: DidCommFcmDeviceInfo }) {
+  public async setDeviceInfo(options: { connectionId: string; deviceInfo: DidCommFcmDeviceInfo }) {
     const { connectionId, deviceInfo } = options
     const connection = await this.connectionService.getById(this.agentContext, connectionId)
     connection.assertReady()
@@ -104,7 +104,6 @@ export class DidCommPushNotificationsFcmApi {
     })
     await this.messageSender.sendMessage(outbound)
   }
-
 
   /**
    * Get push notification record by `connectionId`

--- a/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
+++ b/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
@@ -7,6 +7,7 @@ import {
 } from '@credo-ts/didcomm'
 import {
   DidCommPushNotificationsFcmDeviceInfoHandler,
+  DidCommPushNotificationsFcmGetDeviceInfoHandler,
   DidCommPushNotificationsFcmProblemReportHandler,
   DidCommPushNotificationsFcmSetDeviceInfoHandler,
 } from './handlers/index.js'
@@ -36,6 +37,7 @@ export class DidCommPushNotificationsFcmApi {
       .resolve(DidCommMessageHandlerRegistry)
       .registerMessageHandlers([
         new DidCommPushNotificationsFcmSetDeviceInfoHandler(this.pushNotificationsService),
+        new DidCommPushNotificationsFcmGetDeviceInfoHandler(),
         new DidCommPushNotificationsFcmDeviceInfoHandler(),
         new DidCommPushNotificationsFcmProblemReportHandler(),
       ])

--- a/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
+++ b/packages/push-notifications/src/fcm/DidCommPushNotificationsFcmApi.ts
@@ -41,6 +41,27 @@ export class DidCommPushNotificationsFcmApi {
       ])
   }
 
+ /**
+   * Sends a set request with the fcm device info (token) to another agent via a `connectionId`
+   *
+   * @param connectionId The connection ID string
+   * @param deviceInfo The FCM device info
+   * @returns Promise<void>
+   */
+  public async setDeviceInfo(options: { connectionId: string, deviceInfo: DidCommFcmDeviceInfo }) {
+    const { connectionId, deviceInfo } = options
+    const connection = await this.connectionService.getById(this.agentContext, connectionId)
+    connection.assertReady()
+
+    const message = this.pushNotificationsService.createSetDeviceInfo(deviceInfo)
+
+    const outbound = new DidCommOutboundMessageContext(message, {
+      agentContext: this.agentContext,
+      connection: connection,
+    })
+    await this.messageSender.sendMessage(outbound)
+  }
+
   /**
    * Sends the requested fcm device info (token) to another agent via a `connectionId`
    * Response for `push-notifications-fcm/get-device-info`
@@ -63,6 +84,27 @@ export class DidCommPushNotificationsFcmApi {
     })
     await this.messageSender.sendMessage(outbound)
   }
+
+  /**
+   * Gets the fcm device info (token) from another agent via the `connectionId`
+   *
+   * @param connectionId The connection ID string
+   * @returns Promise<void>
+   */
+  public async getDeviceInfo(options: { connectionId: string }) {
+    const { connectionId } = options
+    const connection = await this.connectionService.getById(this.agentContext, connectionId)
+    connection.assertReady()
+
+    const message = this.pushNotificationsService.createGetDeviceInfo()
+
+    const outbound = new DidCommOutboundMessageContext(message, {
+      agentContext: this.agentContext,
+      connection: connection,
+    })
+    await this.messageSender.sendMessage(outbound)
+  }
+
 
   /**
    * Get push notification record by `connectionId`

--- a/packages/push-notifications/src/fcm/handlers/DidCommPushNotificationsFcmGetDeviceInfoHandler.ts
+++ b/packages/push-notifications/src/fcm/handlers/DidCommPushNotificationsFcmGetDeviceInfoHandler.ts
@@ -1,0 +1,21 @@
+import type { DidCommMessageHandler, DidCommMessageHandlerInboundMessage } from '@credo-ts/didcomm'
+
+import { DidCommPushNotificationsFcmGetDeviceInfoMessage } from '../messages/index.js'
+
+/**
+ * Handler for incoming push notification device info messages
+ */
+export class DidCommPushNotificationsFcmGetDeviceInfoHandler implements DidCommMessageHandler {
+  public supportedMessages = [DidCommPushNotificationsFcmGetDeviceInfoMessage]
+
+  /**
+  /* We don't really need to do anything with this at the moment
+  /* The result can be hooked into through the generic message processed event
+   */
+  public async handle(
+    inboundMessage: DidCommMessageHandlerInboundMessage<DidCommPushNotificationsFcmGetDeviceInfoHandler>
+  ) {
+    inboundMessage.assertReadyConnection()
+    return undefined
+  }
+}

--- a/packages/push-notifications/src/fcm/handlers/index.ts
+++ b/packages/push-notifications/src/fcm/handlers/index.ts
@@ -1,3 +1,4 @@
 export { DidCommPushNotificationsFcmDeviceInfoHandler } from './DidCommPushNotificationsFcmDeviceInfoHandler.js'
+export { DidCommPushNotificationsFcmGetDeviceInfoHandler } from './DidCommPushNotificationsFcmGetDeviceInfoHandler.js'
 export { DidCommPushNotificationsFcmProblemReportHandler } from './DidCommPushNotificationsFcmProblemReportHandler.js'
 export { DidCommPushNotificationsFcmSetDeviceInfoHandler } from './DidCommPushNotificationsFcmSetDeviceInfoHandler.js'


### PR DESCRIPTION
I've noticed that current FCM Push notifications API only includes a method `device-info`, which is supposed to be the response for a `get-device-info`. However, there was no exposed API method to generate a Get Device Info neither a method for Set Device Info (which sends the device info proactively), so I don't know how is this actually working right now. Maybe setting a dummy thread Id on the client-side?

Anyway, here we add these missing `setDeviceInfo` and `getDeviceInfo` methods that were originally coded in previous push notifications extension module.

