### PR TITLE
fix: Correctly handle connection with no firebase record

### DIFF
--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -32,7 +32,7 @@ const setupFirebaseSender = async (agent: Agent) => {
       const pushNotificationRecord = await agent.modules.pushNotificationsFcm.getPushNotificationRecordByConnectionId(
         message.connectionId
       )
-      if (pushNotificationRecord && pushNotificationRecord.deviceToken) {
+      if (pushNotificationRecord?.deviceToken) {
         const repository = agent.dependencyManager.resolve(PushNotificationsFcmRepository)
         sendFcmPushNotification(agent.context, repository, pushNotificationRecord, agent.config.logger as Logger)
       }


### PR DESCRIPTION
Small fix for when a recipient never sends firebase information for the connection. 

Targeting 0.5.x branch