### PR TITLE
feat: coordinate queued live delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,16 @@ ASKAR__DATABASE__TYPE=sqlite # or postgres
 
 # KMS__TYPE=askar (default, only option)
 
+###
+# Debug instrumentation
+###
+
+# Bearer token guarding the runtime log-level toggle (GET/POST /admin/log-level).
+# Used to enable the structured latency-instrumentation logs (LOG_LEVEL=debug
+# equivalent) for a short debug window without a redeploy. Leave unset to keep
+# the admin endpoint disabled (returns 503). Set to a long random string in prod.
+# ADMIN_TOKEN=
+
 # PUSH_NOTIFICATIONS__WEBHOOK_URL=
 
 # Firebase

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,12 @@ ASKAR__DATABASE__TYPE=sqlite # or postgres
 # Debug instrumentation
 ###
 
+# Master switch for the latency debug instrumentation. Default false: the agent
+# runs the stock transports/queue and emits no instrumentation (identical to
+# upstream behaviour). Set true to wire the instrumented components; verbosity is
+# then controlled at runtime via /admin/log-level.
+# INSTRUMENTATION_ENABLED=false
+
 # Bearer token guarding the runtime log-level toggle (GET/POST /admin/log-level).
 # Used to enable the structured latency-instrumentation logs (LOG_LEVEL=debug
 # equivalent) for a short debug window without a redeploy. Leave unset to keep

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,324 @@
+# Mediator Askar to Drizzle Migration Runbook
+
+This is a reusable execution guide for migrating a mediator from Askar storage to Drizzle storage on ECS.
+
+Replace all placeholder values before running:
+
+```text
+<DRIZZLE_DATABASE_URL>       Target Drizzle Postgres URL
+<ASKAR_STORE_ID>            Existing Askar store id
+<ASKAR_STORE_KEY>           Existing Askar store key
+<ASKAR_DATABASE_HOST>       Existing Askar Postgres host:port
+<ASKAR_DATABASE_USER>       Existing Askar Postgres user
+<ASKAR_DATABASE_PASSWORD>   Existing Askar Postgres password
+<ASKAR_DATABASE_ADMIN_USER> Existing Askar Postgres admin user
+<ASKAR_DATABASE_ADMIN_PASSWORD> Existing Askar Postgres admin password
+YYYYMMDD                    Replace this in backup table names with the migration date or another unique suffix
+```
+
+Before starting:
+
+- Stop the real mediator service.
+- Do not run the migration as an ECS service. Use **ECS -> Cluster -> Tasks -> Run task**.
+- Keep the old Askar DB untouched.
+- If retrying after a failed phase 2, reset only the target Drizzle DB schema first.
+
+## Optional Reset Before Retry
+
+Run this in pgAdmin on the target Drizzle DB:
+
+```sql
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP SCHEMA IF EXISTS drizzle CASCADE;
+
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO public;
+```
+
+## Phase 1: Drizzle Schema Migration
+
+### Phase 1 Environment Variables
+
+```json
+[
+  {
+    "name": "STORAGE__TYPE",
+    "value": "drizzle"
+  },
+  {
+    "name": "STORAGE__DIALECT",
+    "value": "postgres"
+  },
+  {
+    "name": "STORAGE__DATABASE_URL",
+    "value": "<DRIZZLE_DATABASE_URL>"
+  },
+  {
+    "name": "DRIZZLE_DATABASE_URL",
+    "value": "<DRIZZLE_DATABASE_URL>"
+  }
+]
+```
+
+### Phase 1 Command
+
+```json
+{
+  "entryPoint": ["sh", "-c"],
+  "command": [
+    "pnpm --filter didcomm-mediator-service run drizzle:migrate:postgres"
+  ]
+}
+```
+
+Expected log:
+
+```text
+migrations applied successfully
+Applying migrations completed successfully
+```
+
+## pgAdmin SQL After Phase 1 And Before Phase 2
+
+Run this in the target Drizzle DB.
+
+First verify tables exist:
+
+```sql
+SELECT table_schema, table_name
+FROM information_schema.tables
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+ORDER BY table_schema, table_name;
+```
+
+You should see tables such as:
+
+```text
+public | DidcommConnection
+public | DidcommMediation
+public | PushNotificationsFcm
+public | StorageVersion
+```
+
+Then run the temporary migration fixes:
+
+```sql
+ALTER TABLE public."DidcommMediation"
+DROP CONSTRAINT IF EXISTS "DidcommMediation_connection_id_context_correlation_id_DidcommCo";
+```
+
+```sql
+ALTER TABLE public."PushNotificationsFcm"
+ALTER COLUMN "created_at" SET DEFAULT now();
+```
+
+```sql
+ALTER TABLE public."PushNotificationsFcm"
+DROP CONSTRAINT IF EXISTS "PushNotificationsFcm_context_correlation_id_connection_id_DidcommConnection_context_correlation_id_id_fk";
+```
+
+## Phase 2: Askar To Drizzle Data Migration
+
+Use the image that includes:
+
+```text
+migrate-askar-to-drizzle:skip-missing-adapters
+```
+
+### Phase 2 Environment Variables
+
+```json
+[
+  {
+    "name": "KMS__TYPE",
+    "value": "askar"
+  },
+  {
+    "name": "ASKAR__STORE_ID",
+    "value": "<ASKAR_STORE_ID>"
+  },
+  {
+    "name": "ASKAR__STORE_KEY",
+    "value": "<ASKAR_STORE_KEY>"
+  },
+  {
+    "name": "ASKAR__KEY_DERIVATION_METHOD",
+    "value": "kdf:argon2i:mod"
+  },
+  {
+    "name": "ASKAR__DATABASE__TYPE",
+    "value": "postgres"
+  },
+  {
+    "name": "ASKAR__DATABASE__HOST",
+    "value": "<ASKAR_DATABASE_HOST>"
+  },
+  {
+    "name": "ASKAR__DATABASE__USER",
+    "value": "<ASKAR_DATABASE_USER>"
+  },
+  {
+    "name": "ASKAR__DATABASE__PASSWORD",
+    "value": "<ASKAR_DATABASE_PASSWORD>"
+  },
+  {
+    "name": "ASKAR__DATABASE__ADMIN_USER",
+    "value": "<ASKAR_DATABASE_ADMIN_USER>"
+  },
+  {
+    "name": "ASKAR__DATABASE__ADMIN_PASSWORD",
+    "value": "<ASKAR_DATABASE_ADMIN_PASSWORD>"
+  },
+  {
+    "name": "STORAGE__TYPE",
+    "value": "drizzle"
+  },
+  {
+    "name": "STORAGE__DIALECT",
+    "value": "postgres"
+  },
+  {
+    "name": "STORAGE__DATABASE_URL",
+    "value": "<DRIZZLE_DATABASE_URL>"
+  },
+  {
+    "name": "DRIZZLE_DATABASE_URL",
+    "value": "<DRIZZLE_DATABASE_URL>"
+  }
+]
+```
+
+### Phase 2 Command
+
+```json
+{
+  "entryPoint": ["sh", "-c"],
+  "command": [
+    "pnpm --filter didcomm-mediator-service run migrate-askar-to-drizzle:skip-missing-adapters"
+  ]
+}
+```
+
+Expected log:
+
+```text
+Successfully initialized drizzle agent
+Successfully initialized askar agent
+Starting migration of default agent context
+Skippping migration of record ... with type 'MessageRecord' due to missing drizzle adapter
+Succesfully migrated default agent context
+Migration complete
+```
+
+The `MessageRecord` skip is expected. It skips old pending queued messages, not reusable connection state.
+
+## pgAdmin SQL After Phase 2
+
+Run this in the target Drizzle DB after phase 2 succeeds.
+
+Back up orphan mediation rows:
+
+```sql
+CREATE TABLE "DidcommMediation_orphan_backup_YYYYMMDD" AS
+SELECT m.*
+FROM "DidcommMediation" m
+LEFT JOIN "DidcommConnection" c
+  ON c."id" = m."connection_id"
+ AND c."context_correlation_id" = m."context_correlation_id"
+WHERE c."id" IS NULL;
+```
+
+Delete orphan mediation rows:
+
+```sql
+DELETE FROM "DidcommMediation" m
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "DidcommConnection" c
+  WHERE c."id" = m."connection_id"
+    AND c."context_correlation_id" = m."context_correlation_id"
+);
+```
+
+Back up orphan push notification rows:
+
+```sql
+CREATE TABLE "PushNotificationsFcm_orphan_backup_YYYYMMDD" AS
+SELECT p.*
+FROM "PushNotificationsFcm" p
+LEFT JOIN "DidcommConnection" c
+  ON c."id" = p."connection_id"
+ AND c."context_correlation_id" = p."context_correlation_id"
+WHERE c."id" IS NULL;
+```
+
+Delete orphan push notification rows:
+
+```sql
+DELETE FROM "PushNotificationsFcm" p
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "DidcommConnection" c
+  WHERE c."id" = p."connection_id"
+    AND c."context_correlation_id" = p."context_correlation_id"
+);
+```
+
+Re-add mediation FK:
+
+```sql
+ALTER TABLE public."DidcommMediation"
+ADD CONSTRAINT "DidcommMediation_connection_id_context_correlation_id_DidcommCo"
+FOREIGN KEY ("connection_id", "context_correlation_id")
+REFERENCES public."DidcommConnection" ("id", "context_correlation_id")
+ON DELETE cascade
+ON UPDATE no action;
+```
+
+Re-add push notification FK:
+
+```sql
+ALTER TABLE public."PushNotificationsFcm"
+ADD CONSTRAINT "PushNotificationsFcm_context_correlation_id_connection_id_DidcommConnection_context_correlation_id_id_fk"
+FOREIGN KEY ("context_correlation_id", "connection_id")
+REFERENCES public."DidcommConnection" ("context_correlation_id", "id")
+ON DELETE cascade
+ON UPDATE no action;
+```
+
+Optional, restore generated schema behavior:
+
+```sql
+ALTER TABLE public."PushNotificationsFcm"
+ALTER COLUMN "created_at" DROP DEFAULT;
+```
+
+## Final Validation
+
+```sql
+SELECT count(*) FROM public."DidcommConnection";
+SELECT count(*) FROM public."DidcommMediation";
+SELECT count(*) FROM public."PushNotificationsFcm";
+SELECT count(*) FROM public."StorageVersion";
+```
+
+```sql
+SELECT count(*)
+FROM "DidcommMediation" m
+LEFT JOIN "DidcommConnection" c
+  ON c."id" = m."connection_id"
+ AND c."context_correlation_id" = m."context_correlation_id"
+WHERE c."id" IS NULL;
+```
+
+```sql
+SELECT count(*)
+FROM "PushNotificationsFcm" p
+LEFT JOIN "DidcommConnection" c
+  ON c."id" = p."connection_id"
+ AND c."context_correlation_id" = p."context_correlation_id"
+WHERE c."id" IS NULL;
+```
+
+Both orphan count queries should return `0`.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ ECS_TASK_DEF_FAMILY ?= QA-ANIMO-MEDIATOR-TDF
 
 # Short git hash of HEAD (7 chars).
 GIT_HASH := $(shell git rev-parse --short=7 HEAD)
+GIT_SHA  := $(shell git rev-parse HEAD)
 IMAGE_TAG := didcomm-mediator-$(GIT_HASH)
 
 # Account id resolved from the selected profile (or env credentials).
@@ -48,13 +49,17 @@ deploy-qa:
 	@$(MAKE) gh-release
 	@$(MAKE) deploy-ecs REMOTE_IMAGE=$(REMOTE_IMAGE)
 
+# owner/repo from origin remote (handles https and ssh URLs).
+GH_REPO = $(shell git config --get remote.origin.url | sed -E 's,git@github.com:,,; s,https://github.com/,,; s,\.git$$,,')
+
 .PHONY: gh-release
 gh-release:
 	@command -v gh >/dev/null || (echo "ERROR: gh CLI is required" && exit 1)
-	@echo ">> Creating GitHub release qa-$(GIT_HASH)..."
+	@echo ">> Creating GitHub release qa-$(GIT_HASH) on $(GH_REPO)..."
 	gh release create qa-$(GIT_HASH) \
+		--repo $(GH_REPO) \
 		--title "qa-$(GIT_HASH)" \
-		--target $(GIT_HASH) \
+		--target $(GIT_SHA) \
 		--generate-notes
 
 .PHONY: deploy-ecs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+# Makefile for building and deploying the DIDComm Mediator image to ECR.
+
+# AWS profile: pass via `make deploy-qa PROFILE=myprofile`.
+# Priority 1: --profile flag (PROFILE var). Otherwise falls back to the
+# AWS_* env vars in the current shell session.
+PROFILE ?=
+AWS_PROFILE_FLAG := $(if $(PROFILE),--profile $(PROFILE),)
+
+AWS_REGION ?= ap-southeast-1
+ECR_REPO   ?= qa-services
+
+# ECS targets (no account id hardcoded; resolved at runtime).
+ECS_CLUSTER   ?= QA-NGOTAG-CLUSTER
+ECS_SERVICE   ?= animo-mediator
+ECS_TASK_DEF_FAMILY ?= QA-ANIMO-MEDIATOR-TDF
+
+# Short git hash of HEAD (7 chars).
+GIT_HASH := $(shell git rev-parse --short=7 HEAD)
+IMAGE_TAG := didcomm-mediator-$(GIT_HASH)
+
+# Account id resolved from the selected profile (or env credentials).
+ACCOUNT_ID = $(shell aws sts get-caller-identity $(AWS_PROFILE_FLAG) --query Account --output text)
+REGISTRY   = $(ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+REMOTE_IMAGE = $(REGISTRY)/$(ECR_REPO):$(IMAGE_TAG)
+LOCAL_IMAGE  = $(ECR_REPO):$(IMAGE_TAG)
+
+.PHONY: deploy-qa
+deploy-qa:
+	@echo ">> Resolving AWS account..."
+	$(eval RESOLVED_ACCOUNT := $(ACCOUNT_ID))
+	@test -n "$(RESOLVED_ACCOUNT)" || (echo "ERROR: could not resolve AWS account id (check --profile or AWS_* env vars)" && exit 1)
+	@echo ">> Account: $(RESOLVED_ACCOUNT)  Image: $(REMOTE_IMAGE)"
+
+	@echo ">> Logging in to ECR..."
+	aws ecr get-login-password $(AWS_PROFILE_FLAG) --region $(AWS_REGION) \
+		| docker login --username AWS --password-stdin $(REGISTRY)
+
+	@echo ">> Building image..."
+	docker build -f apps/mediator/Dockerfile -t $(LOCAL_IMAGE) .
+
+	@echo ">> Tagging image..."
+	docker tag $(LOCAL_IMAGE) $(REMOTE_IMAGE)
+
+	@echo ">> Pushing image..."
+	docker push $(REMOTE_IMAGE)
+
+	@echo ">> Image pushed: $(REMOTE_IMAGE)"
+	@$(MAKE) gh-release
+	@$(MAKE) deploy-ecs REMOTE_IMAGE=$(REMOTE_IMAGE)
+
+.PHONY: gh-release
+gh-release:
+	@command -v gh >/dev/null || (echo "ERROR: gh CLI is required" && exit 1)
+	@echo ">> Creating GitHub release qa-$(GIT_HASH)..."
+	gh release create qa-$(GIT_HASH) \
+		--title "qa-$(GIT_HASH)" \
+		--target $(GIT_HASH) \
+		--generate-notes
+
+.PHONY: deploy-ecs
+deploy-ecs:
+	@command -v jq >/dev/null || (echo "ERROR: jq is required" && exit 1)
+	@test -n "$(REMOTE_IMAGE)" || (echo "ERROR: REMOTE_IMAGE not set" && exit 1)
+	@echo ">> Fetching latest task definition for $(ECS_TASK_DEF_FAMILY)..."
+	@set -e; \
+	tmp=$$(mktemp); \
+	aws ecs describe-task-definition $(AWS_PROFILE_FLAG) --region $(AWS_REGION) \
+		--task-definition $(ECS_TASK_DEF_FAMILY) \
+		--query 'taskDefinition' --output json \
+	| jq --arg img "$(REMOTE_IMAGE)" '\
+		del(.taskDefinitionArn, .revision, .status, .requiresAttributes, \
+		    .compatibilities, .registeredAt, .registeredBy, .deregisteredAt) \
+		| .runtimePlatform = (.runtimePlatform // {}) \
+		| .runtimePlatform.cpuArchitecture = "ARM64" \
+		| .runtimePlatform.operatingSystemFamily = (.runtimePlatform.operatingSystemFamily // "LINUX") \
+		| .containerDefinitions[].image = $$img \
+	' > $$tmp; \
+	echo ">> Registering new task definition (ARM64, image=$(REMOTE_IMAGE))..."; \
+	new_arn=$$(aws ecs register-task-definition $(AWS_PROFILE_FLAG) --region $(AWS_REGION) \
+		--cli-input-json file://$$tmp \
+		--query 'taskDefinition.taskDefinitionArn' --output text); \
+	rm -f $$tmp; \
+	echo ">> Registered: $$new_arn"; \
+	echo ">> Updating service $(ECS_SERVICE) on $(ECS_CLUSTER)..."; \
+	aws ecs update-service $(AWS_PROFILE_FLAG) --region $(AWS_REGION) \
+		--cluster $(ECS_CLUSTER) --service $(ECS_SERVICE) \
+		--task-definition $$new_arn \
+		--query 'service.{service:serviceName,taskDef:taskDefinition}' --output table; \
+	echo ">> Done."

--- a/apps/mediator/package.json
+++ b/apps/mediator/package.json
@@ -20,6 +20,7 @@
     "dev": "vite-node dev.ts",
     "start": "node build/index.js",
     "migrate-askar-to-drizzle": "node build/askarToDrizzleMigration.js",
+    "migrate-askar-to-drizzle:skip-missing-adapters": "node build/askarToDrizzleMigrationSkipMissingAdapters.js",
     "migrate-askar-to-drizzle:dev": "vite-node src/askarToDrizzleMigration.ts",
     "migrate-askar-to-drizzle-delete-storage-records": "node build/askarToDrizzleDeleteAskarStorageRecords.js",
     "migrate-askar-to-drizzle-delete-storage-records:dev": "vite-node src/askarToDrizzleDeleteAskarStorageRecords.ts",

--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -1,7 +1,14 @@
 import type { Socket } from 'node:net'
 import { AskarModule, AskarStoreDuplicateError } from '@credo-ts/askar'
 import { Agent, LogLevel } from '@credo-ts/core'
-import { DidCommMimeType, DidCommModule, DidCommOutOfBandRole, DidCommOutOfBandState } from '@credo-ts/didcomm'
+import {
+  DidCommHttpOutboundTransport,
+  DidCommMimeType,
+  DidCommModule,
+  DidCommOutOfBandRole,
+  DidCommOutOfBandState,
+  DidCommWsOutboundTransport,
+} from '@credo-ts/didcomm'
 import { DidCommPushNotificationsFcmModule } from '@credo-ts/didcomm-push-notifications'
 import { agentDependencies, DidCommHttpInboundTransport, DidCommWsInboundTransport } from '@credo-ts/node'
 import express, { type Express } from 'express'
@@ -47,7 +54,10 @@ async function createModules({
           new DidCommHttpInboundTransport({ app, port: config.agentPort }),
           new DidCommWsInboundTransport({ server: socketServer }),
         ],
-        outbound: [new InstrumentedHttpOutboundTransport(), new InstrumentedWsOutboundTransport()],
+        // Instrumented outbound transports only when enabled; otherwise stock.
+        outbound: config.instrumentationEnabled
+          ? [new InstrumentedHttpOutboundTransport(), new InstrumentedWsOutboundTransport()]
+          : [new DidCommHttpOutboundTransport(), new DidCommWsOutboundTransport()],
       },
 
       connections: {
@@ -123,20 +133,30 @@ export async function createAgent() {
   const socketServer = new WebSocketServer({ noServer: true })
   const redisClient = config.cache.type === 'redis' ? new Redis.default(config.cache.redisUrl) : undefined
 
-  // Debug-instrumentation: runtime log-level toggle endpoint (no-op unless ADMIN_TOKEN is set).
-  registerAdminEndpoints(app, config.adminToken)
+  // Master switch — when off, none of the instrumentation below is wired and the
+  // mediator runs the stock components (see config.instrumentationEnabled).
+  const instrumentationEnabled = config.instrumentationEnabled
 
-  // Debug-instrumentation: WS session lifecycle + inbound fingerprint logging.
-  instrumentSocketServer(socketServer)
+  if (instrumentationEnabled) {
+    // Runtime log-level toggle endpoint (no-op unless ADMIN_TOKEN is set).
+    registerAdminEndpoints(app, config.adminToken)
+    // WS session lifecycle + inbound fingerprint logging.
+    instrumentSocketServer(socketServer)
+  }
 
-  // Flow fix: keep idle live-mode WebSocket connections alive so an intermediary
-  // idle timeout doesn't silently drop them and tear down the live pickup session.
+  // Flow fix (independent of instrumentation): keep idle live-mode WebSocket
+  // connections alive so an intermediary idle timeout doesn't silently drop them
+  // and tear down the live pickup session. Set WS_HEARTBEAT_INTERVAL_SECONDS=0 to
+  // disable for fully-stock WS behaviour.
   startWsHeartbeat(socketServer, config.wsHeartbeatIntervalSeconds * 1000)
 
   // Wrap whichever pickup-queue backend is configured (credo | postgres | dynamodb)
   // so the queue-write / dispatch / forward-strategy hops are emitted uniformly.
+  // When instrumentation is off the raw backend is used unchanged.
   const baseQueueTransportRepository = await loadMessagePickupStorage()
-  const queueTransportRepository = new InstrumentedQueueTransportRepository(baseQueueTransportRepository)
+  const queueTransportRepository = instrumentationEnabled
+    ? new InstrumentedQueueTransportRepository(baseQueueTransportRepository)
+    : baseQueueTransportRepository
   const storageModules = loadStorage()
   const askarModules = await loadAskar()
   const cacheModules = loadCacheStorage({
@@ -160,18 +180,20 @@ export async function createAgent() {
   // agent.initialize() (which registers the POST handler in start()), so this
   // runs first. The outer iv logged here (jwe_fp) is correlated to the inner iv
   // by the DidCommMessageProcessed bridge — no context propagation needed.
-  app.use((req, _res, next) => {
-    if (req.method !== 'POST') return next()
-    const rawBody = typeof req.body === 'string' ? req.body : ''
-    emitStructured(LogLevel.debug, {
-      hop: 'mediator.http.inbound.received',
-      span_id: makeSpanId(),
-      jwe_fp: rawBody ? tryExtractJweFp(rawBody) : '',
-      recipient_key_short: rawBody ? tryExtractRecipientKeyShort(rawBody) : '',
-      content_length: req.headers['content-length'] ? Number(req.headers['content-length']) : undefined,
+  if (instrumentationEnabled) {
+    app.use((req, _res, next) => {
+      if (req.method !== 'POST') return next()
+      const rawBody = typeof req.body === 'string' ? req.body : ''
+      emitStructured(LogLevel.debug, {
+        hop: 'mediator.http.inbound.received',
+        span_id: makeSpanId(),
+        jwe_fp: rawBody ? tryExtractJweFp(rawBody) : '',
+        recipient_key_short: rawBody ? tryExtractRecipientKeyShort(rawBody) : '',
+        content_length: req.headers['content-length'] ? Number(req.headers['content-length']) : undefined,
+      })
+      return next()
     })
-    return next()
-  })
+  }
 
   const agent = new Agent<typeof modules & { askar: AskarModule }>({
     config: {
@@ -248,36 +270,39 @@ export async function createAgent() {
     })
   })
 
-  // Debug-instrumentation: aggregate queue-depth gauge accessor. Only the
-  // in-tree `credo` backend can report total depth from this process; for the
-  // external `postgres` / `dynamodb` backends the gauge omits queue_depth_*
-  // (use per-write mediator.queue.depth.sample + queue.write duration instead).
-  if (baseQueueTransportRepository instanceof StorageServiceMessageQueue) {
-    const credoQueue = baseQueueTransportRepository
-    registerQueueAccessor(() => credoQueue.getQueueStats(agent.context))
+  if (instrumentationEnabled) {
+    // Aggregate queue-depth gauge accessor. Only the in-tree `credo` backend can
+    // report total depth from this process; for the external `postgres` /
+    // `dynamodb` backends the gauge omits queue_depth_* (use per-write
+    // mediator.queue.depth.sample + queue.write duration instead).
+    if (baseQueueTransportRepository instanceof StorageServiceMessageQueue) {
+      const credoQueue = baseQueueTransportRepository
+      registerQueueAccessor(() => credoQueue.getQueueStats(agent.context))
+    }
+
+    // Event-driven correlation bridge + live-session churn diagnostics.
+    wireEventInstrumentation(agent)
+
+    startGauges()
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.config.dump',
+      flow: 'lifecycle',
+      notes: 'effective config at startup',
+      instrumentation_enabled: true,
+      log_level: config.logLevel,
+      message_forwarding_strategy: config.messagePickup.forwardingStrategy,
+      message_pickup_storage: config.messagePickup.storage.type,
+      multi_instance_delivery: config.messagePickup.multiInstanceDelivery.type,
+      cache_type: config.cache.type,
+      storage_type: config.storage.type,
+      askar_database_type: config.askar.database.type,
+      push_notifications_enabled: Boolean(config.pushNotifications.firebase || config.pushNotifications.webhookUrl),
+      admin_endpoint_enabled: Boolean(config.adminToken),
+      ws_heartbeat_interval_seconds: config.wsHeartbeatIntervalSeconds,
+      agent_endpoints: config.agentEndpoints,
+    })
   }
-
-  // Event-driven correlation bridge + live-session churn diagnostics.
-  wireEventInstrumentation(agent)
-
-  startGauges()
-
-  emitStructured(LogLevel.info, {
-    hop: 'mediator.config.dump',
-    flow: 'lifecycle',
-    notes: 'effective config at startup',
-    log_level: config.logLevel,
-    message_forwarding_strategy: config.messagePickup.forwardingStrategy,
-    message_pickup_storage: config.messagePickup.storage.type,
-    multi_instance_delivery: config.messagePickup.multiInstanceDelivery.type,
-    cache_type: config.cache.type,
-    storage_type: config.storage.type,
-    askar_database_type: config.askar.database.type,
-    push_notifications_enabled: Boolean(config.pushNotifications.firebase || config.pushNotifications.webhookUrl),
-    admin_endpoint_enabled: Boolean(config.adminToken),
-    ws_heartbeat_interval_seconds: config.wsHeartbeatIntervalSeconds,
-    agent_endpoints: config.agentEndpoints,
-  })
 
   await loadPushNotificationSender(agent)
   await loadRedisMessageDelivery({

--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -27,7 +27,13 @@ import { wireEventInstrumentation } from './instrumentation/eventInstrumentation
 import { startGauges } from './instrumentation/gauges.js'
 import { InstrumentedQueueTransportRepository } from './instrumentation/InstrumentedQueueTransportRepository.js'
 import { registerQueueAccessor, wsSessionClosed, wsSessionOpened } from './instrumentation/metrics.js'
-import { emitStructured, makeSpanId, tryExtractJweFp, tryExtractRecipientKeyShort } from './logger/StructuredLogger.js'
+import {
+  emitStructured,
+  isStructuredEnabled,
+  makeSpanId,
+  tryExtractJweFp,
+  tryExtractRecipientKeyShort,
+} from './logger/StructuredLogger.js'
 import { StorageServiceMessageQueue } from './storage/StorageMessageQueue.js'
 import { InstrumentedHttpOutboundTransport } from './transports/InstrumentedHttpOutboundTransport.js'
 import { InstrumentedWsOutboundTransport } from './transports/InstrumentedWsOutboundTransport.js'
@@ -103,6 +109,7 @@ function instrumentSocketServer(socketServer: WebSocketServer): void {
     })
 
     socket.on('message', (data) => {
+      if (!isStructuredEnabled(LogLevel.debug)) return
       const raw = wsDataToString(data)
       emitStructured(LogLevel.debug, {
         hop: 'mediator.ws.inbound.received',
@@ -183,6 +190,7 @@ export async function createAgent() {
   if (instrumentationEnabled) {
     app.use((req, _res, next) => {
       if (req.method !== 'POST') return next()
+      if (!isStructuredEnabled(LogLevel.debug)) return next()
       const rawBody = typeof req.body === 'string' ? req.body : ''
       emitStructured(LogLevel.debug, {
         hop: 'mediator.http.inbound.received',

--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -1,18 +1,12 @@
 import type { Socket } from 'node:net'
 import { AskarModule, AskarStoreDuplicateError } from '@credo-ts/askar'
-import { Agent } from '@credo-ts/core'
-import {
-  DidCommHttpOutboundTransport,
-  DidCommMimeType,
-  DidCommModule,
-  DidCommOutOfBandRole,
-  DidCommOutOfBandState,
-  DidCommWsOutboundTransport,
-} from '@credo-ts/didcomm'
+import { Agent, LogLevel } from '@credo-ts/core'
+import { DidCommMimeType, DidCommModule, DidCommOutOfBandRole, DidCommOutOfBandState } from '@credo-ts/didcomm'
 import { DidCommPushNotificationsFcmModule } from '@credo-ts/didcomm-push-notifications'
 import { agentDependencies, DidCommHttpInboundTransport, DidCommWsInboundTransport } from '@credo-ts/node'
 import express, { type Express } from 'express'
 import Redis from 'ioredis'
+import type { WebSocket } from 'ws'
 import { WebSocketServer } from 'ws'
 import { loadAskar } from './config/askarLoader.js'
 import { loadCacheStorage } from './config/cacheLoader.js'
@@ -21,6 +15,16 @@ import { loadPushNotificationSender } from './config/pushNotificationLoader.js'
 import { loadRedisMessageDelivery } from './config/redisMessageDeliveryLoader.js'
 import { loadStorage } from './config/storageLoader.js'
 import { config, logger } from './config.js'
+import { registerAdminEndpoints } from './instrumentation/adminEndpoint.js'
+import { wireEventInstrumentation } from './instrumentation/eventInstrumentation.js'
+import { startGauges } from './instrumentation/gauges.js'
+import { InstrumentedQueueTransportRepository } from './instrumentation/InstrumentedQueueTransportRepository.js'
+import { registerQueueAccessor, wsSessionClosed, wsSessionOpened } from './instrumentation/metrics.js'
+import { emitStructured, makeSpanId, tryExtractJweFp, tryExtractRecipientKeyShort } from './logger/StructuredLogger.js'
+import { StorageServiceMessageQueue } from './storage/StorageMessageQueue.js'
+import { InstrumentedHttpOutboundTransport } from './transports/InstrumentedHttpOutboundTransport.js'
+import { InstrumentedWsOutboundTransport } from './transports/InstrumentedWsOutboundTransport.js'
+import { startWsHeartbeat } from './transports/wsHeartbeat.js'
 
 async function createModules({
   queueTransportRepository,
@@ -43,7 +47,7 @@ async function createModules({
           new DidCommHttpInboundTransport({ app, port: config.agentPort }),
           new DidCommWsInboundTransport({ server: socketServer }),
         ],
-        outbound: [new DidCommHttpOutboundTransport(), new DidCommWsOutboundTransport()],
+        outbound: [new InstrumentedHttpOutboundTransport(), new InstrumentedWsOutboundTransport()],
       },
 
       connections: {
@@ -65,6 +69,53 @@ async function createModules({
   return modules
 }
 
+function wsDataToString(data: unknown): string {
+  if (typeof data === 'string') return data
+  if (Buffer.isBuffer(data)) return data.toString('utf8')
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString('utf8')
+  return ''
+}
+
+// Debug-instrumentation: per-WS-session lifecycle + inbound fingerprint logging.
+// Transport-level only (raw `socket.on`, no monkey-patching) — the message-level
+// outer↔inner correlation is handled reliably by wireEventInstrumentation() via
+// Credo's DidCommMessageProcessed event, which exposes both envelopes.
+function instrumentSocketServer(socketServer: WebSocketServer): void {
+  socketServer.on('connection', (socket: WebSocket) => {
+    const sessionId = makeSpanId()
+    wsSessionOpened()
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.ws.session.opened',
+      flow: 'lifecycle',
+      span_id: sessionId,
+      recipient_key_short: '',
+      notes: 'recipient_key resolved on first message',
+    })
+
+    socket.on('message', (data) => {
+      const raw = wsDataToString(data)
+      emitStructured(LogLevel.debug, {
+        hop: 'mediator.ws.inbound.received',
+        span_id: makeSpanId(),
+        jwe_fp: raw ? tryExtractJweFp(raw) : '',
+        recipient_key_short: raw ? tryExtractRecipientKeyShort(raw) : '',
+        session_id: sessionId,
+        byte_length: raw.length,
+      })
+    })
+
+    socket.on('close', () => {
+      wsSessionClosed()
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.ws.session.closed',
+        flow: 'lifecycle',
+        span_id: sessionId,
+        recipient_key_short: '',
+      })
+    })
+  })
+}
+
 export async function createAgent() {
   // We create our own instance of express here. This is not required
   // but allows use to use the same server (and port) for both WebSockets and HTTP
@@ -72,7 +123,20 @@ export async function createAgent() {
   const socketServer = new WebSocketServer({ noServer: true })
   const redisClient = config.cache.type === 'redis' ? new Redis.default(config.cache.redisUrl) : undefined
 
-  const queueTransportRepository = await loadMessagePickupStorage()
+  // Debug-instrumentation: runtime log-level toggle endpoint (no-op unless ADMIN_TOKEN is set).
+  registerAdminEndpoints(app, config.adminToken)
+
+  // Debug-instrumentation: WS session lifecycle + inbound fingerprint logging.
+  instrumentSocketServer(socketServer)
+
+  // Flow fix: keep idle live-mode WebSocket connections alive so an intermediary
+  // idle timeout doesn't silently drop them and tear down the live pickup session.
+  startWsHeartbeat(socketServer, config.wsHeartbeatIntervalSeconds * 1000)
+
+  // Wrap whichever pickup-queue backend is configured (credo | postgres | dynamodb)
+  // so the queue-write / dispatch / forward-strategy hops are emitted uniformly.
+  const baseQueueTransportRepository = await loadMessagePickupStorage()
+  const queueTransportRepository = new InstrumentedQueueTransportRepository(baseQueueTransportRepository)
   const storageModules = loadStorage()
   const askarModules = await loadAskar()
   const cacheModules = loadCacheStorage({
@@ -89,6 +153,25 @@ export async function createAgent() {
       socketServer,
     })),
   } as const
+
+  // Debug-instrumentation: HTTP inbound fingerprint logging. Registered AFTER
+  // createModules() (so the DidCommHttpInboundTransport's express.text() body
+  // parser is already in place and req.body is the raw string) and BEFORE
+  // agent.initialize() (which registers the POST handler in start()), so this
+  // runs first. The outer iv logged here (jwe_fp) is correlated to the inner iv
+  // by the DidCommMessageProcessed bridge — no context propagation needed.
+  app.use((req, _res, next) => {
+    if (req.method !== 'POST') return next()
+    const rawBody = typeof req.body === 'string' ? req.body : ''
+    emitStructured(LogLevel.debug, {
+      hop: 'mediator.http.inbound.received',
+      span_id: makeSpanId(),
+      jwe_fp: rawBody ? tryExtractJweFp(rawBody) : '',
+      recipient_key_short: rawBody ? tryExtractRecipientKeyShort(rawBody) : '',
+      content_length: req.headers['content-length'] ? Number(req.headers['content-length']) : undefined,
+    })
+    return next()
+  })
 
   const agent = new Agent<typeof modules & { askar: AskarModule }>({
     config: {
@@ -163,6 +246,37 @@ export async function createAgent() {
     socketServer.handleUpgrade(request, socket as Socket, head, (socket) => {
       socketServer.emit('connection', socket, request)
     })
+  })
+
+  // Debug-instrumentation: aggregate queue-depth gauge accessor. Only the
+  // in-tree `credo` backend can report total depth from this process; for the
+  // external `postgres` / `dynamodb` backends the gauge omits queue_depth_*
+  // (use per-write mediator.queue.depth.sample + queue.write duration instead).
+  if (baseQueueTransportRepository instanceof StorageServiceMessageQueue) {
+    const credoQueue = baseQueueTransportRepository
+    registerQueueAccessor(() => credoQueue.getQueueStats(agent.context))
+  }
+
+  // Event-driven correlation bridge + live-session churn diagnostics.
+  wireEventInstrumentation(agent)
+
+  startGauges()
+
+  emitStructured(LogLevel.info, {
+    hop: 'mediator.config.dump',
+    flow: 'lifecycle',
+    notes: 'effective config at startup',
+    log_level: config.logLevel,
+    message_forwarding_strategy: config.messagePickup.forwardingStrategy,
+    message_pickup_storage: config.messagePickup.storage.type,
+    multi_instance_delivery: config.messagePickup.multiInstanceDelivery.type,
+    cache_type: config.cache.type,
+    storage_type: config.storage.type,
+    askar_database_type: config.askar.database.type,
+    push_notifications_enabled: Boolean(config.pushNotifications.firebase || config.pushNotifications.webhookUrl),
+    admin_endpoint_enabled: Boolean(config.adminToken),
+    ws_heartbeat_interval_seconds: config.wsHeartbeatIntervalSeconds,
+    agent_endpoints: config.agentEndpoints,
   })
 
   await loadPushNotificationSender(agent)

--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -3,10 +3,12 @@ import { AskarModule, AskarStoreDuplicateError } from '@credo-ts/askar'
 import { Agent, LogLevel } from '@credo-ts/core'
 import {
   DidCommHttpOutboundTransport,
+  DidCommMediatorService,
   DidCommMimeType,
   DidCommModule,
   DidCommOutOfBandRole,
   DidCommOutOfBandState,
+  DidCommTransportService,
   DidCommWsOutboundTransport,
 } from '@credo-ts/didcomm'
 import { DidCommPushNotificationsFcmModule } from '@credo-ts/didcomm-push-notifications'
@@ -25,6 +27,7 @@ import { config, logger } from './config.js'
 import { registerAdminEndpoints } from './instrumentation/adminEndpoint.js'
 import { wireEventInstrumentation } from './instrumentation/eventInstrumentation.js'
 import { startGauges } from './instrumentation/gauges.js'
+import { InstrumentedMediatorService } from './instrumentation/InstrumentedMediatorService.js'
 import { InstrumentedQueueTransportRepository } from './instrumentation/InstrumentedQueueTransportRepository.js'
 import { registerQueueAccessor, wsSessionClosed, wsSessionOpened } from './instrumentation/metrics.js'
 import {
@@ -36,6 +39,7 @@ import {
 } from './logger/StructuredLogger.js'
 import { StorageServiceMessageQueue } from './storage/StorageMessageQueue.js'
 import { InstrumentedHttpOutboundTransport } from './transports/InstrumentedHttpOutboundTransport.js'
+import { InstrumentedTransportService } from './transports/InstrumentedTransportService.js'
 import { InstrumentedWsOutboundTransport } from './transports/InstrumentedWsOutboundTransport.js'
 import { startWsHeartbeat } from './transports/wsHeartbeat.js'
 
@@ -211,6 +215,22 @@ export async function createAgent() {
     dependencies: agentDependencies,
     modules: modules as typeof modules & { askar: AskarModule },
   })
+
+  if (instrumentationEnabled) {
+    // Override two Credo singletons with instrumented subclasses, to capture the
+    // forward-delivery signals that no event/outbound-transport hook can see:
+    //   - DidCommTransportService → wraps session.send for the LIVE delivery path
+    //     (DirectDelivery's sendPackage uses session.send directly, bypassing
+    //     outbound transports).
+    //   - DidCommMediatorService → wraps processForwardMessage for the per-forward
+    //     strategy decision + Undeliverable outcome (sendPackage / the queue never
+    //     emit DidCommMessageSent).
+    // Done before agent.initialize() so the override is in place before either
+    // service is first resolved (during module init / message handling). The
+    // subclasses delegate to super for all behaviour — instrumentation only.
+    agent.dependencyManager.registerSingleton(DidCommTransportService, InstrumentedTransportService)
+    agent.dependencyManager.registerSingleton(DidCommMediatorService, InstrumentedMediatorService)
+  }
 
   // Added health check endpoint
   app.get('/health', async (_req, res) => {

--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -37,6 +37,7 @@ import {
   tryExtractJweFp,
   tryExtractRecipientKeyShort,
 } from './logger/StructuredLogger.js'
+import { CoordinatedMediatorService } from './message-delivery/CoordinatedMediatorService.js'
 import { StorageServiceMessageQueue } from './storage/StorageMessageQueue.js'
 import { InstrumentedHttpOutboundTransport } from './transports/InstrumentedHttpOutboundTransport.js'
 import { InstrumentedTransportService } from './transports/InstrumentedTransportService.js'
@@ -216,8 +217,13 @@ export async function createAgent() {
     modules: modules as typeof modules & { askar: AskarModule },
   })
 
+  // Credo owns local live delivery after queueing a forwarded message. Marking
+  // that path lets the Redis queue listener avoid issuing the same delivery in
+  // parallel. The instrumented implementation extends this service.
+  agent.dependencyManager.registerSingleton(DidCommMediatorService, CoordinatedMediatorService)
+
   if (instrumentationEnabled) {
-    // Override two Credo singletons with instrumented subclasses, to capture the
+    // Register instrumented subclasses for two Credo singletons, to capture the
     // forward-delivery signals that no event/outbound-transport hook can see:
     //   - DidCommTransportService → wraps session.send for the LIVE delivery path
     //     (DirectDelivery's sendPackage uses session.send directly, bypassing

--- a/apps/mediator/src/askarToDrizzleMigrationSkipMissingAdapters.ts
+++ b/apps/mediator/src/askarToDrizzleMigrationSkipMissingAdapters.ts
@@ -1,0 +1,28 @@
+import { AskarToDrizzleStorageMigrator } from '@credo-ts/askar-to-drizzle-storage-migration'
+import { agentDependencies } from '@credo-ts/node'
+import { loadAskar } from './config/askarLoader.js'
+import { loadStorage } from './config/storageLoader.js'
+import { logger } from './config.js'
+
+export async function askarToDrizzleMigrationSkipMissingAdapters() {
+  const { askar: askarModule } = await loadAskar({ enableStorage: true })
+  if (!askarModule) throw new Error('Expected Askar to be configured')
+
+  const { drizzle: drizzleModule } = loadStorage()
+  if (!drizzleModule) throw new Error('Expected Drizzle to be configured')
+
+  const migrator = await AskarToDrizzleStorageMigrator.initialize({
+    drizzleModule,
+    agentDependencies,
+    logger,
+    askarModule,
+    skipMigrationForMissingAdapter: true,
+  })
+
+  await migrator.migrate()
+}
+
+askarToDrizzleMigrationSkipMissingAdapters().then(() => {
+  logger.info('Migration complete')
+  process.exit()
+})

--- a/apps/mediator/src/config.ts
+++ b/apps/mediator/src/config.ts
@@ -341,6 +341,24 @@ const zConfig = z
       })
       .optional(),
     invitationGoalCode: z.string().optional(),
+    // Bearer token guarding the debug-instrumentation /admin/log-level endpoint.
+    // If unset, the endpoint is disabled (returns 503). Set via ADMIN_TOKEN.
+    adminToken: z
+      .string({
+        error:
+          "Admin token must be a string. Guards the /admin/log-level debug endpoint. Can also be set using 'ADMIN_TOKEN' environment variable",
+      })
+      .optional(),
+    // Server-side WebSocket keepalive interval (seconds). Pings idle live-mode
+    // sockets so an intermediary idle timeout does not silently drop them and
+    // tear down the live pickup session. Set to 0 to disable. Env:
+    // WS_HEARTBEAT_INTERVAL_SECONDS.
+    wsHeartbeatIntervalSeconds: z.coerce
+      .number({
+        error:
+          "WS heartbeat interval must be a number of seconds (0 disables). Can also be set using 'WS_HEARTBEAT_INTERVAL_SECONDS' environment variable",
+      })
+      .default(30),
     createNewInvitation: z
       .enum(['true', 'false'])
       .transform((v) => v === 'true')

--- a/apps/mediator/src/config.ts
+++ b/apps/mediator/src/config.ts
@@ -341,6 +341,19 @@ const zConfig = z
       })
       .optional(),
     invitationGoalCode: z.string().optional(),
+    // Master switch for the latency debug instrumentation. When false (default)
+    // the agent wires the STOCK transports / queue repository and registers no
+    // instrumentation middleware, event subscribers, gauges or admin endpoint —
+    // behaviour is identical to upstream and no instrumentation code runs on the
+    // hot path. When true, the instrumented components are wired and the
+    // /admin/log-level endpoint controls verbosity at runtime. Env:
+    // INSTRUMENTATION_ENABLED.
+    instrumentationEnabled: z
+      .enum(['true', 'false'])
+      .transform((v) => v === 'true')
+      .or(z.boolean())
+      .optional()
+      .default(false),
     // Bearer token guarding the debug-instrumentation /admin/log-level endpoint.
     // If unset, the endpoint is disabled (returns 503). Set via ADMIN_TOKEN.
     adminToken: z

--- a/apps/mediator/src/config/redisMessageDeliveryLoader.ts
+++ b/apps/mediator/src/config/redisMessageDeliveryLoader.ts
@@ -4,6 +4,9 @@ import Redis from 'ioredis'
 import type { MediatorAgent } from '../agent.js'
 import { config } from '../config.js'
 import { DidcommMessageQueuedEvent, MediatorEventTypes } from '../events.js'
+import { shouldCredoOwnLocalDelivery } from '../message-delivery/deliveryOwnership.js'
+import { isInForwardDeliveryContext } from '../message-delivery/forwardDeliveryContext.js'
+import { KeyedSingleFlight } from '../message-delivery/KeyedSingleFlight.js'
 import { RedisStreamMessagePublishing } from '../multi-instance/redis-stream-message-publishing/redisStreamMessagePublishing.js'
 import { sendNotification } from '../push-notifications/sendNotification.js'
 
@@ -45,6 +48,28 @@ export async function loadRedisMessageDelivery({
   // if a server crashes we lose the active socket connections.
   const streamPublishing = new RedisStreamMessagePublishing(agent, client, randomUUID())
 
+  const localDelivery = new KeyedSingleFlight(async (connectionId: string): Promise<boolean> => {
+    try {
+      const session = await agent.didcomm.messagePickup.getLiveModeSession({
+        connectionId,
+        role: DidCommMessagePickupSessionRole.MessageHolder,
+      })
+
+      if (!session) return false
+
+      agent.config.logger.debug('Found a local session. Delivering messages from queue.', { connectionId })
+      await agent.didcomm.messagePickup.deliverMessagesFromQueue({
+        pickupSessionId: session.id,
+      })
+      agent.config.logger.debug('Successfully delivered queued messages to a local session.', { connectionId })
+
+      return true
+    } catch (error) {
+      agent.config.logger.debug('Unable to deliver queued messages to a local session.', { connectionId, error })
+      return false
+    }
+  })
+
   agent.events.on<DidcommMessageQueuedEvent>(MediatorEventTypes.DidCommMessageQueued, async (event) => {
     const connectionId = event.payload.connectionId
 
@@ -52,43 +77,42 @@ export async function loadRedisMessageDelivery({
       `Server ${streamPublishing.serverId} received DidCommMessageQuedEvent for connection ${connectionId}`
     )
 
-    // TODO: do we want to handle when we don't want to send to local sessions?
     if (config.messagePickup.forwardingStrategy !== DidCommMessageForwardingStrategy.DirectDelivery) {
-      agent.config.logger.debug(
-        'Trying to send queued message to session directly, since forwarding strategy is set to QueueOnly',
-        { connectionId }
-      )
-      try {
-        const session = await agent.didcomm.messagePickup.getLiveModeSession({
-          connectionId,
-          role: DidCommMessagePickupSessionRole.MessageHolder,
-        })
+      const isForwardQueueEvent = isInForwardDeliveryContext()
 
-        if (session) {
-          agent.config.logger.debug(
-            'Found a local session to send queued message to session directly. Delivering messages from queue',
-            { connectionId }
-          )
-          await agent.didcomm.messagePickup.deliverMessagesFromQueue({
-            pickupSessionId: session.id,
+      // In QueueAndLiveModeDelivery, Credo's processForwardMessage queues the
+      // message and then performs local delivery itself. The queue event is
+      // emitted before that delivery, so handling it here too races two reads
+      // and two WebSocket sends for the same message. Only skip events marked
+      // by that path; messages queued by any other caller still use this path.
+      if (
+        config.messagePickup.forwardingStrategy === DidCommMessageForwardingStrategy.QueueAndLiveModeDelivery &&
+        isForwardQueueEvent
+      ) {
+        try {
+          const session = await agent.didcomm.messagePickup.getLiveModeSession({
+            connectionId,
+            role: DidCommMessagePickupSessionRole.MessageHolder,
           })
 
-          agent.config.logger.debug(
-            'Found a local session to send queued message to session directly. Delivering messages from queue',
-            { connectionId }
-          )
-
-          // We succeeded in delivering the message. We can return
-          return
+          if (
+            shouldCredoOwnLocalDelivery({
+              forwardingStrategy: config.messagePickup.forwardingStrategy,
+              hasLocalSession: Boolean(session),
+              isForwardQueueEvent,
+            })
+          ) {
+            agent.config.logger.debug(
+              'Credo forward delivery owns the local session; skipping duplicate Redis-triggered delivery.',
+              { connectionId }
+            )
+            return
+          }
+        } catch (error) {
+          agent.config.logger.debug('Unable to verify local forward-delivery ownership.', { connectionId, error })
         }
-
-        // We didn't send the message yet, we need to check other instances
-      } catch (_error) {
-        agent.config.logger.debug(
-          // In case of an error we didn't send the message yet, we need to check other instances
-          'An error occurred while retrieving or sending queued messages to a local session. Continuing with other servers or falling back to sending a push notifications.',
-          { connectionId }
-        )
+      } else if (await localDelivery.schedule(connectionId)) {
+        return
       }
     }
 
@@ -149,42 +173,16 @@ export async function loadRedisMessageDelivery({
         `Server '${streamPublishing.serverId}' received message ${message.id} for connection '${message.payload.connectionId}'. Attempting to deliver to local session.`
       )
 
-      const pickupSession = await agent.didcomm.messagePickup.getLiveModeSession({
-        connectionId: message.payload.connectionId,
-        role: DidCommMessagePickupSessionRole.MessageHolder,
-      })
-
-      if (pickupSession) {
-        try {
-          agent.config.logger.debug(
-            `Found local session for connection '${message.payload.connectionId}'. Delivering messages from queue.`
-          )
-
-          await agent.didcomm.messagePickup.deliverMessagesFromQueue({
-            pickupSessionId: pickupSession.id,
-          })
-
-          agent.config.logger.debug(
-            `Successfully delivered messages to local session for connection '${message.payload.connectionId}' for message ${message.id}`
-          )
-
-          // We delivered the messages, we don't have to send a push notification
-          // Improvement: If we haven't received an ack in X seconds, we should still
-          // send the push notification
-          return
-        } catch (error) {
-          // In case an error occurred with the delivery of the message, we will send a push notification
-          agent.config.logger.debug(
-            `Error delivering message ${message.id} to local session for connection '${message.payload.connectionId}'. Falling back to push notification.`,
-            { error }
-          )
-        }
-      } else {
-        agent.config.logger.debug(
-          `No local session found for connection '${message.payload.connectionId}'. Falling back to push notification.`
-        )
+      if (await localDelivery.schedule(message.payload.connectionId)) {
+        // We delivered the messages, so no push notification is needed. If
+        // several stream entries target this connection, they share this
+        // flight and at most one follow-up queue drain is scheduled.
+        return
       }
 
+      agent.config.logger.debug(
+        `No usable local session found for connection '${message.payload.connectionId}'. Falling back to push notification.`
+      )
       await sendNotification(agent.context, message.payload.connectionId)
     },
     { signal: abortSignal }

--- a/apps/mediator/src/config/storageLoader.ts
+++ b/apps/mediator/src/config/storageLoader.ts
@@ -15,16 +15,20 @@ export function loadStorage(): { drizzle?: DrizzleStorageModule } {
 
     let database: ReturnType<typeof drizzlePostgres> | ReturnType<typeof drizzleSqlite>
     if (storage.dialect === 'postgres') {
-      // Construct the pg Pool explicitly (behaviourally identical to letting
-      // drizzle create it from the URL) so the debug gauge can read live pool
-      // stats — the direct diagnostic for connection-pool saturation under load.
-      const pool = new Pool({ connectionString: storage.databaseUrl })
-      registerDbPoolAccessor(() => ({
-        total: pool.totalCount,
-        idle: pool.idleCount,
-        waiting: pool.waitingCount,
-      }))
-      database = drizzlePostgres(pool)
+      if (config.instrumentationEnabled) {
+        // Construct the pg Pool explicitly (behaviourally identical to letting
+        // drizzle create it from the URL) so the debug gauge can read live pool
+        // stats — the direct diagnostic for connection-pool saturation under load.
+        const pool = new Pool({ connectionString: storage.databaseUrl })
+        registerDbPoolAccessor(() => ({
+          total: pool.totalCount,
+          idle: pool.idleCount,
+          waiting: pool.waitingCount,
+        }))
+        database = drizzlePostgres(pool)
+      } else {
+        database = drizzlePostgres(storage.databaseUrl)
+      }
     } else {
       database = drizzleSqlite(storage.databaseUrl)
     }

--- a/apps/mediator/src/config/storageLoader.ts
+++ b/apps/mediator/src/config/storageLoader.ts
@@ -2,8 +2,10 @@ import { DrizzleStorageModule } from '@credo-ts/drizzle-storage'
 import { didcommBundle } from '@credo-ts/drizzle-storage/didcomm'
 import { drizzle as drizzleSqlite } from 'drizzle-orm/libsql'
 import { drizzle as drizzlePostgres } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
 import { config, logger } from '../config.js'
 import { mediatorBundle } from '../drizzle/bundle.js'
+import { registerDbPoolAccessor } from '../instrumentation/metrics.js'
 
 export function loadStorage(): { drizzle?: DrizzleStorageModule } {
   const { storage } = config
@@ -11,8 +13,21 @@ export function loadStorage(): { drizzle?: DrizzleStorageModule } {
   if (storage.type === 'drizzle') {
     logger.info('Using drizzle storage')
 
-    const database =
-      storage.dialect === 'postgres' ? drizzlePostgres(storage.databaseUrl) : drizzleSqlite(storage.databaseUrl)
+    let database: ReturnType<typeof drizzlePostgres> | ReturnType<typeof drizzleSqlite>
+    if (storage.dialect === 'postgres') {
+      // Construct the pg Pool explicitly (behaviourally identical to letting
+      // drizzle create it from the URL) so the debug gauge can read live pool
+      // stats — the direct diagnostic for connection-pool saturation under load.
+      const pool = new Pool({ connectionString: storage.databaseUrl })
+      registerDbPoolAccessor(() => ({
+        total: pool.totalCount,
+        idle: pool.idleCount,
+        waiting: pool.waitingCount,
+      }))
+      database = drizzlePostgres(pool)
+    } else {
+      database = drizzleSqlite(storage.databaseUrl)
+    }
 
     return {
       drizzle: new DrizzleStorageModule({

--- a/apps/mediator/src/instrumentation/InstrumentedMediatorService.ts
+++ b/apps/mediator/src/instrumentation/InstrumentedMediatorService.ts
@@ -5,7 +5,6 @@ import {
   type DidCommInboundMessageContext,
   DidCommMediationRepository,
   DidCommMediatorRoutingRepository,
-  DidCommMediatorService,
 } from '@credo-ts/didcomm'
 
 import { config } from '../config.js'
@@ -17,6 +16,7 @@ import {
   truncateKey,
   tryExtractJweFp,
 } from '../logger/StructuredLogger.js'
+import { CoordinatedMediatorService } from '../message-delivery/CoordinatedMediatorService.js'
 
 // Instruments the mediator forward path directly, because the underlying
 // delivery (DidCommMessageSender.sendPackage for DirectDelivery, or the pickup
@@ -37,9 +37,10 @@ import {
 //   - Instrumented*OutboundTransport         → service endpoint (SentToTransport)
 //
 // Registered on the DidCommMediatorService DI token (see agent.ts) only when
-// instrumentation is enabled; otherwise the stock service is used unchanged.
+// instrumentation is enabled; otherwise the non-instrumented coordinated
+// service is used.
 @injectable()
-export class InstrumentedMediatorService extends DidCommMediatorService {
+export class InstrumentedMediatorService extends CoordinatedMediatorService {
   public constructor(
     mediationRepository: DidCommMediationRepository,
     mediatorRoutingRepository: DidCommMediatorRoutingRepository,

--- a/apps/mediator/src/instrumentation/InstrumentedMediatorService.ts
+++ b/apps/mediator/src/instrumentation/InstrumentedMediatorService.ts
@@ -1,0 +1,99 @@
+import { EventEmitter, InjectionSymbols, inject, injectable, type Logger, LogLevel } from '@credo-ts/core'
+import {
+  DidCommConnectionService,
+  type DidCommForwardMessage,
+  type DidCommInboundMessageContext,
+  DidCommMediationRepository,
+  DidCommMediatorRoutingRepository,
+  DidCommMediatorService,
+} from '@credo-ts/didcomm'
+
+import { config } from '../config.js'
+import {
+  durationMs,
+  emitStructured,
+  makeSpanId,
+  monoNow,
+  truncateKey,
+  tryExtractJweFp,
+} from '../logger/StructuredLogger.js'
+
+// Instruments the mediator forward path directly, because the underlying
+// delivery (DidCommMessageSender.sendPackage for DirectDelivery, or the pickup
+// queue for QueueOnly / QueueAndLiveModeDelivery) does NOT emit
+// DidCommMessageSent — so the DidCommMessageSent listener in
+// eventInstrumentation never sees forwarded user traffic.
+//
+// processForwardMessage is the single entry point for every forwarded message,
+// so wrapping it gives us, per forward:
+//   - mediator.forward.strategy.decision — the configured strategy + recipient
+//   - the Undeliverable outcome (sendPackage throws when no session / no
+//     transport / no queue is available; DirectDelivery has no queue fallback)
+//
+// The successful-delivery breakdown (live vs queue vs service-endpoint) is
+// emitted by the layers sendPackage actually flows through:
+//   - InstrumentedTransportService          → live session.send (SentToSession)
+//   - InstrumentedQueueTransportRepository   → queue write (QueuedForPickup)
+//   - Instrumented*OutboundTransport         → service endpoint (SentToTransport)
+//
+// Registered on the DidCommMediatorService DI token (see agent.ts) only when
+// instrumentation is enabled; otherwise the stock service is used unchanged.
+@injectable()
+export class InstrumentedMediatorService extends DidCommMediatorService {
+  public constructor(
+    mediationRepository: DidCommMediationRepository,
+    mediatorRoutingRepository: DidCommMediatorRoutingRepository,
+    eventEmitter: EventEmitter,
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    connectionService: DidCommConnectionService
+  ) {
+    super(mediationRepository, mediatorRoutingRepository, eventEmitter, logger, connectionService)
+  }
+
+  public override async processForwardMessage(
+    messageContext: DidCommInboundMessageContext<DidCommForwardMessage>
+  ): Promise<void> {
+    const spanId = makeSpanId()
+    const startMono = monoNow()
+    const { message } = messageContext
+
+    // The inner (forwarded) JWE iv — joins to mediator.forward.bridge.jwe_fp_out
+    // and to the recipient's inbound. Best-effort; never let it disturb routing.
+    let jweFp = ''
+    let recipientKeyShort = ''
+    try {
+      jweFp = tryExtractJweFp(message.message)
+      recipientKeyShort = message.to ? truncateKey(message.to) : ''
+    } catch {
+      // best-effort
+    }
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.forward.strategy.decision',
+      flow: 'pickup',
+      span_id: spanId,
+      jwe_fp: jweFp,
+      recipient_key_short: recipientKeyShort,
+      decision: config.messagePickup.forwardingStrategy,
+    })
+
+    try {
+      await super.processForwardMessage(messageContext)
+    } catch (err) {
+      // sendPackage throws CredoError when the message is undeliverable (no live
+      // session, no outbound transport, no queue). This is the direct signal for
+      // the "DirectDelivery first attempt fails, retry works" observation.
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.message.sent',
+        flow: 'pickup',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        recipient_key_short: recipientKeyShort,
+        status: 'Undeliverable',
+        duration_ms: durationMs(startMono),
+        notes: err instanceof Error ? err.message.slice(0, 120) : 'unknown error',
+      })
+      throw err
+    }
+  }
+}

--- a/apps/mediator/src/instrumentation/InstrumentedQueueTransportRepository.ts
+++ b/apps/mediator/src/instrumentation/InstrumentedQueueTransportRepository.ts
@@ -1,0 +1,127 @@
+import type { Agent, AgentContext } from '@credo-ts/core'
+import { LogLevel } from '@credo-ts/core'
+import type {
+  AddMessageOptions,
+  GetAvailableMessageCountOptions,
+  QueuedDidCommMessage,
+  RemoveMessagesOptions,
+  TakeFromQueueOptions,
+} from '@credo-ts/didcomm'
+
+import type { ExtendedQueueTransportRepository } from '../config/messagePickupLoader.js'
+import { durationMs, emitStructured, makeSpanId, monoNow, tryExtractJweFp } from '../logger/StructuredLogger.js'
+import { recordQueueWrite } from './metrics.js'
+
+// Wraps ANY DidCommQueueTransportRepository (the in-tree `credo` queue, or the
+// `postgres` / `dynamodb` backends) and emits the queue-side instrumentation
+// hops. Decorating the repository here — rather than editing each backend —
+// means every pickup-storage type is covered uniformly, and the external
+// backend packages stay untouched (umbrella convention: instrument in the
+// consuming repo, not in `@credo-ts/*`).
+export class InstrumentedQueueTransportRepository implements ExtendedQueueTransportRepository {
+  public constructor(private readonly inner: ExtendedQueueTransportRepository) {}
+
+  public initialize(agent: Agent): Promise<void> {
+    return this.inner.initialize?.(agent) ?? Promise.resolve()
+  }
+
+  public getAvailableMessageCount(
+    agentContext: AgentContext,
+    options: GetAvailableMessageCountOptions
+  ): number | Promise<number> {
+    return this.inner.getAvailableMessageCount(agentContext, options)
+  }
+
+  public removeMessages(agentContext: AgentContext, options: RemoveMessagesOptions): void | Promise<void> {
+    return this.inner.removeMessages(agentContext, options)
+  }
+
+  public async takeFromQueue(
+    agentContext: AgentContext,
+    options: TakeFromQueueOptions
+  ): Promise<QueuedDidCommMessage[]> {
+    const { connectionId, limit } = options
+    const spanId = makeSpanId()
+    const startMono = monoNow()
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.pickup.batch.dispatch.start',
+      flow: 'pickup',
+      span_id: spanId,
+      conn_id: connectionId,
+      pickup_limit: limit,
+    })
+
+    const messages = await this.inner.takeFromQueue(agentContext, options)
+
+    // Per-message inner-JWE fingerprints, so the analyst can join a dispatch
+    // event back to the queue write that produced each message.
+    const dispatchedFingerprints = messages.map((m) => tryExtractJweFp(m.encryptedMessage)).filter(Boolean)
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.pickup.batch.dispatch.end',
+      flow: 'pickup',
+      span_id: spanId,
+      conn_id: connectionId,
+      duration_ms: durationMs(startMono),
+      message_count: messages.length,
+      delete_messages: options.deleteMessages ?? false,
+      dispatched_jwe_fps: dispatchedFingerprints,
+    })
+
+    return messages
+  }
+
+  public async addMessage(agentContext: AgentContext, options: AddMessageOptions): Promise<string> {
+    const { connectionId, payload } = options
+
+    // jwe_fp_out: inner JWE fingerprint — the payload being queued, which the
+    // mobile wallet will unpack. Joins to the recipient's inbound and, via the
+    // mediator.forward.bridge line, back to the outer iv the sender transport saw.
+    const jweFpOut = tryExtractJweFp(payload)
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.forward.strategy.decision',
+      conn_id: connectionId,
+      jwe_fp_out: jweFpOut,
+      decision: 'queue',
+    })
+
+    const spanId = makeSpanId()
+    const startMono = monoNow()
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.queue.write.start',
+      span_id: spanId,
+      conn_id: connectionId,
+      jwe_fp_out: jweFpOut,
+    })
+
+    const id = await this.inner.addMessage(agentContext, options)
+
+    recordQueueWrite()
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.queue.write.end',
+      span_id: spanId,
+      conn_id: connectionId,
+      jwe_fp_out: jweFpOut,
+      duration_ms: durationMs(startMono),
+    })
+
+    // Per-connection queue depth after the write — fire-and-forget so the
+    // count never blocks the delivery path. Works for every backend (standard
+    // repository method), unlike the aggregate gauge.
+    void Promise.resolve(this.inner.getAvailableMessageCount(agentContext, { connectionId }))
+      .then((queueDepth) => {
+        emitStructured(LogLevel.info, {
+          hop: 'mediator.queue.depth.sample',
+          conn_id: connectionId,
+          queue_depth_after: queueDepth,
+        })
+      })
+      .catch(() => {
+        // best-effort
+      })
+
+    return id
+  }
+}

--- a/apps/mediator/src/instrumentation/adminEndpoint.ts
+++ b/apps/mediator/src/instrumentation/adminEndpoint.ts
@@ -1,0 +1,56 @@
+import { LogLevel } from '@credo-ts/core'
+import express, { type Express, type Request, type Response } from 'express'
+
+import { getDebugLogLevel, setDebugLogLevel } from './logLevelHolder.js'
+
+const LOG_LEVEL_MAP: Record<string, LogLevel> = {
+  test: LogLevel.test,
+  trace: LogLevel.trace,
+  debug: LogLevel.debug,
+  info: LogLevel.info,
+  warn: LogLevel.warn,
+  error: LogLevel.error,
+  fatal: LogLevel.fatal,
+  off: LogLevel.off,
+}
+
+// Runtime toggle for the debug-instrumentation log level. Lets an operator
+// dial the structured-logging verbosity up (e.g. to `debug`) for a 15-minute
+// debug window and back down to `info`/`warn` afterwards WITHOUT a redeploy —
+// avoiding the WS-reconnect churn a rolling ECS deploy would cause.
+//
+// Guarded by a bearer token. If ADMIN_TOKEN is unset the endpoint returns 503
+// (disabled) so it can never be left open by accident.
+export function registerAdminEndpoints(app: Express, adminToken: string | undefined): void {
+  function authMiddleware(req: Request, res: Response, next: () => void): void {
+    if (!adminToken) {
+      res.status(503).json({ error: 'admin endpoint disabled (ADMIN_TOKEN not set)' })
+      return
+    }
+    const authHeader = req.headers.authorization
+    if (!authHeader || authHeader !== `Bearer ${adminToken}`) {
+      res.status(401).json({ error: 'unauthorized' })
+      return
+    }
+    next()
+  }
+
+  app.use('/admin', express.json())
+
+  app.get('/admin/log-level', authMiddleware, (_req: Request, res: Response) => {
+    const current = getDebugLogLevel()
+    const name = Object.entries(LOG_LEVEL_MAP).find(([, v]) => v === current)?.[0] ?? String(current)
+    res.json({ level: name, service: 'mediator' })
+  })
+
+  app.post('/admin/log-level', authMiddleware, (req: Request, res: Response) => {
+    const body = req.body as Record<string, unknown>
+    const level = body?.level
+    if (typeof level !== 'string' || !(level in LOG_LEVEL_MAP)) {
+      res.status(400).json({ error: 'invalid level', valid: Object.keys(LOG_LEVEL_MAP) })
+      return
+    }
+    setDebugLogLevel(LOG_LEVEL_MAP[level])
+    res.json({ level, service: 'mediator', ok: true })
+  })
+}

--- a/apps/mediator/src/instrumentation/eventInstrumentation.ts
+++ b/apps/mediator/src/instrumentation/eventInstrumentation.ts
@@ -5,6 +5,7 @@ import {
   DidCommMessagePickupEventTypes,
   type DidCommMessagePickupLiveSessionSavedEvent,
   type DidCommMessageProcessedEvent,
+  type DidCommMessageReceivedEvent,
   type DidCommMessageSentEvent,
   type MessagePickupCompletedEvent,
   type MessagePickupLiveSessionRemovedEvent,
@@ -30,7 +31,27 @@ import { emitStructured, truncateKey, tryExtractJweFp } from '../logger/Structur
 //
 // The bridge line is the join: match X against the sender side, Y against the
 // recipient side. No iv needs to be carried across async boundaries.
+
+// Instrumentation-owned receive timestamps. Credo 0.6.0 does not populate
+// `receivedAt` on DidCommMessageReceived / DidCommMessageProcessed for HTTP or
+// WS inbound traffic, so we record it ourselves here. Keyed by the deserialized
+// message object, which is the same reference in both events. WeakMap ensures
+// entries are GC'd with the message object — no manual cleanup needed.
+const receiveTimestamps = new WeakMap<object, number>()
+
 export function wireEventInstrumentation(agent: MediatorAgent): void {
+  // Capture receive time before the message handler chain runs. The message
+  // object is the same reference that DidCommMessageProcessed will carry.
+  agent.events.on<DidCommMessageReceivedEvent>(DidCommEventTypes.DidCommMessageReceived, (event) => {
+    try {
+      if (event.payload.message && typeof event.payload.message === 'object') {
+        receiveTimestamps.set(event.payload.message as object, Date.now())
+      }
+    } catch {
+      // best-effort
+    }
+  })
+
   // Outer↔inner bridge: emitted once per forwarded message.
   //
   // `processing_ms` (inbound receivedAt → fully processed) is the in-mediator
@@ -41,8 +62,10 @@ export function wireEventInstrumentation(agent: MediatorAgent): void {
   // as this value climbing while inbound→outbound network time stays flat.
   agent.events.on<DidCommMessageProcessedEvent>(DidCommEventTypes.DidCommMessageProcessed, (event) => {
     try {
-      const { message, encryptedMessage, connection, receivedAt } = event.payload
+      const { message, encryptedMessage, connection } = event.payload
       if (!(message instanceof DidCommForwardMessage)) return
+
+      const receiveTs = receiveTimestamps.get(message)
 
       emitStructured(LogLevel.info, {
         hop: 'mediator.forward.bridge',
@@ -50,7 +73,7 @@ export function wireEventInstrumentation(agent: MediatorAgent): void {
         jwe_fp_out: tryExtractJweFp(message.message),
         recipient_key_short: message.to ? truncateKey(message.to) : '',
         conn_id: connection?.id ?? '',
-        processing_ms: receivedAt ? Date.now() - receivedAt.getTime() : undefined,
+        processing_ms: receiveTs !== undefined ? Date.now() - receiveTs : undefined,
       })
     } catch {
       // best-effort — instrumentation must never disturb message processing

--- a/apps/mediator/src/instrumentation/eventInstrumentation.ts
+++ b/apps/mediator/src/instrumentation/eventInstrumentation.ts
@@ -1,0 +1,126 @@
+import { LogLevel } from '@credo-ts/core'
+import {
+  DidCommEventTypes,
+  DidCommForwardMessage,
+  DidCommMessagePickupEventTypes,
+  type DidCommMessagePickupLiveSessionSavedEvent,
+  type DidCommMessageProcessedEvent,
+  type DidCommMessageSentEvent,
+  type MessagePickupCompletedEvent,
+  type MessagePickupLiveSessionRemovedEvent,
+} from '@credo-ts/didcomm'
+
+import type { MediatorAgent } from '../agent.js'
+import { emitStructured, truncateKey, tryExtractJweFp } from '../logger/StructuredLogger.js'
+
+// Event-driven correlation + live-session diagnostics.
+//
+// This is the efficient replacement for the old mediator's fragile
+// AsyncLocalStorage + WS-socket-monkey-patching "bridge". Credo 0.6.x emits
+// DidCommMessageProcessed with BOTH the decoded message AND the raw outer
+// `encryptedMessage`, so for a DIDComm v1 Forward we can read the outer JWE
+// fingerprint (X, what the sender/controller transport saw) and the inner JWE
+// fingerprint (Y, what the recipient/mobile will unpack) from a SINGLE event,
+// synchronously, with no context propagation and no patching.
+//
+//   sender/controller transport ── X ──▶ mediator inbound (X)
+//                                              │  forward.bridge { jwe_fp_in: X, jwe_fp_out: Y }
+//                                              ▼
+//                              mediator outbound / queue (Y) ── Y ──▶ recipient/mobile inbound (Y)
+//
+// The bridge line is the join: match X against the sender side, Y against the
+// recipient side. No iv needs to be carried across async boundaries.
+export function wireEventInstrumentation(agent: MediatorAgent): void {
+  // Outer↔inner bridge: emitted once per forwarded message.
+  //
+  // `processing_ms` (inbound receivedAt → fully processed) is the in-mediator
+  // handling time: decrypt + route + (for DirectDelivery) the synchronous send,
+  // or the queue write. It is the direct signal for the "DirectDelivery is fast
+  // with little data but slows under DB load / first request fast then
+  // subsequent slow" observation — a storage/connection-pool bottleneck shows up
+  // as this value climbing while inbound→outbound network time stays flat.
+  agent.events.on<DidCommMessageProcessedEvent>(DidCommEventTypes.DidCommMessageProcessed, (event) => {
+    try {
+      const { message, encryptedMessage, connection, receivedAt } = event.payload
+      if (!(message instanceof DidCommForwardMessage)) return
+
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.forward.bridge',
+        jwe_fp_in: encryptedMessage ? tryExtractJweFp(encryptedMessage) : '',
+        jwe_fp_out: tryExtractJweFp(message.message),
+        recipient_key_short: message.to ? truncateKey(message.to) : '',
+        conn_id: connection?.id ?? '',
+        processing_ms: receivedAt ? Date.now() - receivedAt.getTime() : undefined,
+      })
+    } catch {
+      // best-effort — instrumentation must never disturb message processing
+    }
+  })
+
+  // Outbound delivery outcome. `status` is one of SentToSession |
+  // SentToTransport | QueuedForPickup | Undeliverable. This is the direct signal
+  // for the "DirectDelivery new connection fails on first try, works on second"
+  // observation: with DirectDelivery there is no queue fallback, so a message
+  // sent before the recipient's inbound (WS) transport session exists comes back
+  // `Undeliverable`. A sustained share of Undeliverable / a live:queue ratio
+  // shifting toward QueuedForPickup over time both surface here.
+  agent.events.on<DidCommMessageSentEvent>(DidCommEventTypes.DidCommMessageSent, (event) => {
+    try {
+      const ctx = event.payload.message
+      const threadId = (ctx.message as { threadId?: string } | undefined)?.threadId
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.message.sent',
+        status: event.payload.status,
+        conn_id: ctx.connection?.id ?? '',
+        message_type: ctx.message?.type,
+        thread_id: threadId ?? '',
+      })
+    } catch {
+      // best-effort
+    }
+  })
+
+  // Live-mode pickup session lifecycle. The gap between a WS staying open
+  // (mediator.ws.session.*) and the live session being removed here is the
+  // direct signal for the "live session torn down by transient HTTP pickup
+  // churn" hypothesis: a saved→removed pair while the WS is still open means a
+  // message that could have been live-delivered fell back to slow queue pickup.
+  agent.events.on<DidCommMessagePickupLiveSessionSavedEvent>(
+    DidCommMessagePickupEventTypes.LiveSessionSaved,
+    (event) => {
+      const s = event.payload.session
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.live.session.saved',
+        flow: 'pickup',
+        conn_id: s.connectionId,
+        session_id: s.id,
+        role: s.role,
+        protocol_version: String(s.protocolVersion),
+        transport_session_id: s.transportSessionId,
+      })
+    }
+  )
+
+  agent.events.on<MessagePickupLiveSessionRemovedEvent>(DidCommMessagePickupEventTypes.LiveSessionRemoved, (event) => {
+    const s = event.payload.session
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.live.session.removed',
+      flow: 'pickup',
+      conn_id: s.connectionId,
+      session_id: s.id,
+      role: s.role,
+      protocol_version: String(s.protocolVersion),
+      transport_session_id: s.transportSessionId,
+    })
+  })
+
+  // Pickup completion carries the pickup-protocol thread id + connection.
+  agent.events.on<MessagePickupCompletedEvent>(DidCommMessagePickupEventTypes.MessagePickupCompleted, (event) => {
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.pickup.completed',
+      flow: 'pickup',
+      conn_id: event.payload.connection.id,
+      thread_id: event.payload.threadId ?? '',
+    })
+  })
+}

--- a/apps/mediator/src/instrumentation/eventInstrumentation.ts
+++ b/apps/mediator/src/instrumentation/eventInstrumentation.ts
@@ -34,14 +34,22 @@ import { emitStructured, truncateKey, tryExtractJweFp } from '../logger/Structur
 
 // Instrumentation-owned receive timestamps. Credo 0.6.0 does not populate
 // `receivedAt` on DidCommMessageReceived / DidCommMessageProcessed for HTTP or
-// WS inbound traffic, so we record it ourselves here. Keyed by the deserialized
-// message object, which is the same reference in both events. WeakMap ensures
-// entries are GC'd with the message object — no manual cleanup needed.
+// WS inbound traffic, so we record it ourselves here.
+//
+// Keyed by the OUTER encrypted-message object, NOT the decrypted message: the
+// two events carry different objects. DidCommMessageReceived.payload.message is
+// the raw encrypted JWE that the inbound transport handed to the receiver, and
+// that exact reference flows through (receiveMessage → InboundMessageContext →
+// dispatcher) to DidCommMessageProcessed.payload.encryptedMessage. The decoded
+// `message` on the processed event is a freshly-constructed DidCommMessage and
+// would never match. WeakMap ensures entries are GC'd with the JWE object — no
+// manual cleanup needed.
 const receiveTimestamps = new WeakMap<object, number>()
 
 export function wireEventInstrumentation(agent: MediatorAgent): void {
-  // Capture receive time before the message handler chain runs. The message
-  // object is the same reference that DidCommMessageProcessed will carry.
+  // Capture receive time before the message handler chain runs. `payload.message`
+  // here is the outer encrypted JWE — the same reference that surfaces as
+  // `encryptedMessage` on DidCommMessageProcessed below.
   agent.events.on<DidCommMessageReceivedEvent>(DidCommEventTypes.DidCommMessageReceived, (event) => {
     try {
       if (event.payload.message && typeof event.payload.message === 'object') {
@@ -65,7 +73,9 @@ export function wireEventInstrumentation(agent: MediatorAgent): void {
       const { message, encryptedMessage, connection } = event.payload
       if (!(message instanceof DidCommForwardMessage)) return
 
-      const receiveTs = receiveTimestamps.get(message)
+      // Look up by the outer encrypted message — the same object reference that
+      // DidCommMessageReceived carried as `payload.message` (see WeakMap note).
+      const receiveTs = encryptedMessage ? receiveTimestamps.get(encryptedMessage) : undefined
 
       emitStructured(LogLevel.info, {
         hop: 'mediator.forward.bridge',
@@ -80,13 +90,20 @@ export function wireEventInstrumentation(agent: MediatorAgent): void {
     }
   })
 
-  // Outbound delivery outcome. `status` is one of SentToSession |
-  // SentToTransport | QueuedForPickup | Undeliverable. This is the direct signal
-  // for the "DirectDelivery new connection fails on first try, works on second"
-  // observation: with DirectDelivery there is no queue fallback, so a message
-  // sent before the recipient's inbound (WS) transport session exists comes back
-  // `Undeliverable`. A sustained share of Undeliverable / a live:queue ratio
-  // shifting toward QueuedForPickup over time both surface here.
+  // Outbound delivery outcome for messages the mediator sends via
+  // DidCommMessageSender.sendMessage(outboundMessageContext) — i.e. the
+  // mediator's OWN coordination traffic (mediation grants, keylist responses,
+  // pickup status/delivery). `status` is SentToSession | SentToTransport |
+  // QueuedForPickup | Undeliverable.
+  //
+  // NOTE: this does NOT cover forwarded user messages. The mediator forward
+  // path routes via DidCommMessageSender.sendPackage() (DirectDelivery) or the
+  // pickup queue, neither of which emits DidCommMessageSent. The forward
+  // delivery outcome is instrumented directly instead:
+  //   - strategy decision + undeliverable → InstrumentedMediatorService
+  //   - live session delivery (SentToSession) → InstrumentedTransportService
+  //   - queue write (QueuedForPickup)        → InstrumentedQueueTransportRepository
+  //   - service-endpoint send (SentToTransport) → Instrumented*OutboundTransport
   agent.events.on<DidCommMessageSentEvent>(DidCommEventTypes.DidCommMessageSent, (event) => {
     try {
       const ctx = event.payload.message

--- a/apps/mediator/src/instrumentation/gauges.ts
+++ b/apps/mediator/src/instrumentation/gauges.ts
@@ -7,6 +7,13 @@ const GAUGE_INTERVAL_MS = 10_000
 
 let _gaugeTimer: ReturnType<typeof setInterval> | null = null
 
+// True while a queue-depth sample is still outstanding. Promise.race times out
+// the gauge tick's *reporting*, but it cannot cancel the underlying accessor()
+// query — so on a saturated DB those diagnostic queries would otherwise pile up
+// across ticks and add load during the exact incident we're measuring. This
+// guard skips issuing a new sample until the previous one settles.
+let _queueSampleInFlight = false
+
 // Emits one `mediator.gauge.snapshot` line every 10s (fixed cadence so the
 // analysis script can resample without alignment guesswork). Carries WS-session
 // counters, outbound p50/p95 latency to the controller, queue writes per 10s,
@@ -17,12 +24,24 @@ export function startGauges(): void {
     const snap = snapshotAndReset()
 
     // Queue stats: fetch with a 1s timeout so a slow DB never stalls the tick.
+    // Skip entirely if the previous sample's query hasn't settled yet, so slow
+    // queries can't stack up across ticks (the 1s race only caps reporting, not
+    // the query itself).
     let queueFields: Record<string, unknown> = {}
     const accessor = getQueueAccessor()
-    if (accessor) {
+    if (accessor && _queueSampleInFlight) {
+      queueFields = { queue_sample_skipped: true }
+    } else if (accessor) {
+      _queueSampleInFlight = true
+      // Settle the in-flight flag when the real query finishes — NOT when the
+      // 1s race resolves — so the next tick only resumes sampling once the DB
+      // has actually responded.
+      const queryPromise = accessor().finally(() => {
+        _queueSampleInFlight = false
+      })
       try {
         const qSnap = await Promise.race([
-          accessor(),
+          queryPromise,
           new Promise<null>((resolve) => setTimeout(() => resolve(null), 1000)),
         ])
         if (qSnap) {
@@ -31,9 +50,14 @@ export function startGauges(): void {
             queue_oldest_age_ms: qSnap.oldestAgeMs,
             queue_depth_top10: qSnap.top10,
           }
+        } else {
+          // 1s timeout won the race; the query is still running and will clear
+          // the in-flight flag itself when it settles.
+          queueFields = { queue_sample_timeout: true }
         }
       } catch {
-        // best-effort — never let a gauge tick throw
+        // best-effort — never let a gauge tick throw. The .finally above still
+        // clears the in-flight flag on rejection.
       }
     }
 

--- a/apps/mediator/src/instrumentation/gauges.ts
+++ b/apps/mediator/src/instrumentation/gauges.ts
@@ -1,0 +1,75 @@
+import { LogLevel } from '@credo-ts/core'
+
+import { emitStructured } from '../logger/StructuredLogger.js'
+import { getDbPoolAccessor, getQueueAccessor, snapshotAndReset } from './metrics.js'
+
+const GAUGE_INTERVAL_MS = 10_000
+
+let _gaugeTimer: ReturnType<typeof setInterval> | null = null
+
+// Emits one `mediator.gauge.snapshot` line every 10s (fixed cadence so the
+// analysis script can resample without alignment guesswork). Carries WS-session
+// counters, outbound p50/p95 latency to the controller, queue writes per 10s,
+// and — when a queue accessor is registered — aggregate queue depth.
+export function startGauges(): void {
+  if (_gaugeTimer) return
+  _gaugeTimer = setInterval(async () => {
+    const snap = snapshotAndReset()
+
+    // Queue stats: fetch with a 1s timeout so a slow DB never stalls the tick.
+    let queueFields: Record<string, unknown> = {}
+    const accessor = getQueueAccessor()
+    if (accessor) {
+      try {
+        const qSnap = await Promise.race([
+          accessor(),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 1000)),
+        ])
+        if (qSnap) {
+          queueFields = {
+            queue_depth_total: qSnap.total,
+            queue_oldest_age_ms: qSnap.oldestAgeMs,
+            queue_depth_top10: qSnap.top10,
+          }
+        }
+      } catch {
+        // best-effort — never let a gauge tick throw
+      }
+    }
+
+    // DB pool stats are in-memory counters on the pg Pool — read synchronously.
+    let dbPoolFields: Record<string, unknown> = {}
+    const dbAccessor = getDbPoolAccessor()
+    if (dbAccessor) {
+      try {
+        const s = dbAccessor()
+        if (s) {
+          dbPoolFields = {
+            db_pool_total: s.total,
+            db_pool_idle: s.idle,
+            db_pool_waiting: s.waiting,
+          }
+        }
+      } catch {
+        // best-effort
+      }
+    }
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.gauge.snapshot',
+      flow: 'lifecycle',
+      ...snap,
+      ...queueFields,
+      ...dbPoolFields,
+    })
+  }, GAUGE_INTERVAL_MS)
+  // Don't keep the process alive solely for the gauge.
+  if (_gaugeTimer.unref) _gaugeTimer.unref()
+}
+
+export function stopGauges(): void {
+  if (_gaugeTimer) {
+    clearInterval(_gaugeTimer)
+    _gaugeTimer = null
+  }
+}

--- a/apps/mediator/src/instrumentation/logLevelHolder.ts
+++ b/apps/mediator/src/instrumentation/logLevelHolder.ts
@@ -1,0 +1,17 @@
+import { LogLevel } from '@credo-ts/core'
+
+// Runtime-toggleable log level for the debug instrumentation. Held separately
+// from the agent's own logger so the /admin/log-level endpoint can dial the
+// structured-instrumentation verbosity up and down during a debug window
+// without a redeploy (no WS-reconnect storms). Defaults to `info`, which means
+// the verbose `debug`-level hop lines (inbound transport fingerprints) stay off
+// until explicitly enabled.
+let _level: LogLevel = LogLevel.info
+
+export function getDebugLogLevel(): LogLevel {
+  return _level
+}
+
+export function setDebugLogLevel(level: LogLevel): void {
+  _level = level
+}

--- a/apps/mediator/src/instrumentation/metrics.ts
+++ b/apps/mediator/src/instrumentation/metrics.ts
@@ -1,0 +1,100 @@
+// Shared in-memory counters and rolling windows used by both the 10s gauge
+// emitter and the instrumented transports / queue-repository wrapper.
+
+type QueueStatsAccessor = () => Promise<{
+  total: number
+  oldestAgeMs: number
+  top10: Array<{ connId: string; count: number }>
+} | null>
+
+let _queueAccessor: QueueStatsAccessor | null = null
+
+// Registered only when the pickup-queue backend can report aggregate depth
+// (the in-tree `credo` StorageServiceMessageQueue). For the `postgres` /
+// `dynamodb` backends the queue lives in an external store this process does
+// not own, so the accessor stays null and `queue_depth_*` gauge fields are
+// omitted — use per-write `mediator.queue.depth.sample` (per-connection) and
+// `mediator.queue.write.end.duration_ms` growth as indirect signals instead.
+export function registerQueueAccessor(fn: QueueStatsAccessor): void {
+  _queueAccessor = fn
+}
+
+export function getQueueAccessor(): QueueStatsAccessor | null {
+  return _queueAccessor
+}
+
+type DbPoolStatsAccessor = () => { total: number; idle: number; waiting: number } | null
+
+let _dbPoolAccessor: DbPoolStatsAccessor | null = null
+
+// Registered by the storage loader when the Drizzle Postgres pool is in use, so
+// the gauge can expose db_pool_total / db_pool_idle / db_pool_waiting. A growing
+// `waiting` under load while latency climbs is the direct signal for the
+// "DirectDelivery first request fast, subsequent slow under DB load"
+// observation (connection-pool saturation). Null for sqlite/dev.
+export function registerDbPoolAccessor(fn: DbPoolStatsAccessor): void {
+  _dbPoolAccessor = fn
+}
+
+export function getDbPoolAccessor(): DbPoolStatsAccessor | null {
+  return _dbPoolAccessor
+}
+
+let _wsSessionsActive = 0
+const _outboundMs: number[] = []
+let _queueWritesLast10s = 0
+let _wsOpened10s = 0
+let _wsClosed10s = 0
+
+export function wsSessionOpened(): void {
+  _wsSessionsActive++
+  _wsOpened10s++
+}
+
+export function wsSessionClosed(): void {
+  _wsSessionsActive = Math.max(0, _wsSessionsActive - 1)
+  _wsClosed10s++
+}
+
+export function recordOutboundMs(ms: number): void {
+  _outboundMs.push(ms)
+  if (_outboundMs.length > 1000) _outboundMs.shift()
+}
+
+export function recordQueueWrite(): void {
+  _queueWritesLast10s++
+}
+
+export interface GaugeSnapshot {
+  ws_sessions_active: number
+  ws_sessions_opened_10s: number
+  ws_sessions_closed_10s: number
+  outbound_p50_ms: number | null
+  outbound_p95_ms: number | null
+  outbound_sample_n: number
+  queue_writes_10s: number
+}
+
+export function snapshotAndReset(): GaugeSnapshot {
+  const sorted = [..._outboundMs].sort((a, b) => a - b)
+  const n = sorted.length
+  const p50 = n > 0 ? sorted[Math.floor(n * 0.5)] : null
+  const p95 = n > 0 ? sorted[Math.floor(n * 0.95)] : null
+
+  const snap: GaugeSnapshot = {
+    ws_sessions_active: _wsSessionsActive,
+    ws_sessions_opened_10s: _wsOpened10s,
+    ws_sessions_closed_10s: _wsClosed10s,
+    outbound_p50_ms: p50,
+    outbound_p95_ms: p95,
+    outbound_sample_n: n,
+    queue_writes_10s: _queueWritesLast10s,
+  }
+
+  _outboundMs.length = 0
+  _wsOpened10s = 0
+  _wsClosed10s = 0
+  _queueWritesLast10s = 0
+
+  return snap
+}

--- a/apps/mediator/src/logger/Logger.ts
+++ b/apps/mediator/src/logger/Logger.ts
@@ -1,7 +1,7 @@
 import { BaseLogger, LogLevel } from '@credo-ts/core'
 import { ILogObj, Logger as TSLogger } from 'tslog'
 
-import { replaceError } from './replaceError.js'
+import { createSafeJsonReplacer } from './replaceError.js'
 
 export class Logger extends BaseLogger {
   private logger: TSLogger<ILogObj>
@@ -33,7 +33,7 @@ export class Logger extends BaseLogger {
     if (this.logLevel === LogLevel.off) return
 
     if (data) {
-      this.logger[tsLogLevel](message, JSON.parse(JSON.stringify(data, replaceError, 2)))
+      this.logger[tsLogLevel](message, JSON.parse(JSON.stringify(data, createSafeJsonReplacer(), 2)))
     } else {
       this.logger[tsLogLevel](message)
     }

--- a/apps/mediator/src/logger/StructuredLogger.ts
+++ b/apps/mediator/src/logger/StructuredLogger.ts
@@ -1,0 +1,145 @@
+import * as os from 'node:os'
+import { LogLevel } from '@credo-ts/core'
+
+import { getDebugLogLevel } from '../instrumentation/logLevelHolder.js'
+
+// Structured, single-line-JSON debug instrumentation for latency root-causing.
+// The field schema and `hop` enum are kept in sync with the sibling repos
+// (ngotag-agent-controller, Bhutanndi-app) so the three services' logs can be
+// mechanically joined into one per-flow timeline. See Debug/debug-plan.md.
+export type HopName =
+  | 'mediator.config.dump'
+  | 'mediator.http.inbound.received'
+  | 'mediator.ws.inbound.received'
+  | 'mediator.ws.session.opened'
+  | 'mediator.ws.session.closed'
+  | 'mediator.forward.bridge'
+  | 'mediator.forward.strategy.decision'
+  | 'mediator.message.sent'
+  | 'mediator.live.session.saved'
+  | 'mediator.live.session.removed'
+  | 'mediator.pickup.completed'
+  | 'mediator.queue.write.start'
+  | 'mediator.queue.write.end'
+  | 'mediator.queue.depth.sample'
+  | 'mediator.live.delivery.start'
+  | 'mediator.live.delivery.end'
+  | 'mediator.outbound.send.start'
+  | 'mediator.outbound.send.end'
+  | 'mediator.pickup.request.received'
+  | 'mediator.pickup.batch.dispatch.start'
+  | 'mediator.pickup.batch.dispatch.end'
+  | 'mediator.push.send.start'
+  | 'mediator.push.send.end'
+  | 'mediator.gauge.snapshot'
+
+export type FlowType = 'connection' | 'issuance' | 'verification' | 'pickup' | 'mediation-coord' | 'lifecycle'
+
+export interface StructuredLogLine {
+  hop: HopName
+  flow?: FlowType
+  thread_id?: string
+  jwe_fp?: string
+  jwe_fp_in?: string
+  jwe_fp_out?: string
+  recipient_key_short?: string
+  conn_id?: string
+  span_id?: string
+  duration_ms?: number
+  notes?: string
+  [key: string]: unknown
+}
+
+const TASK_HOST = process.env.ECS_CONTAINER_METADATA_URI ? process.env.HOSTNAME || os.hostname() : os.hostname()
+
+// Emit a structured instrumentation line to stdout (captured by the log
+// aggregator). Gated behind the runtime-toggleable debug level so it can be
+// silenced outside a debug window without a redeploy.
+export function emitStructured(level: LogLevel, line: StructuredLogLine): void {
+  if (level < getDebugLogLevel()) return
+
+  const out: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    ts_mono_ns: Number(process.hrtime.bigint()),
+    service: 'mediator',
+    task_host: TASK_HOST,
+    ...line,
+  }
+
+  // Drop undefined/empty fields to keep lines compact, except the key
+  // correlation fields, whose absence is itself a finding at analysis time.
+  const KEEP_EMPTY = new Set(['thread_id', 'jwe_fp', 'jwe_fp_in', 'jwe_fp_out'])
+  for (const key of Object.keys(out)) {
+    if (out[key] === undefined || out[key] === '') {
+      if (!KEEP_EMPTY.has(key)) delete out[key]
+    }
+  }
+
+  process.stdout.write(`${JSON.stringify(out)}\n`)
+}
+
+export function makeSpanId(): string {
+  return Math.random().toString(36).slice(2, 10) + Math.random().toString(36).slice(2, 10)
+}
+
+export function monoNow(): number {
+  return Number(process.hrtime.bigint())
+}
+
+export function durationMs(startMono: number): number {
+  return Math.round((Number(process.hrtime.bigint()) - startMono) / 1e6)
+}
+
+export function truncateKey(key: string): string {
+  if (key.length <= 14) return key
+  return `${key.slice(0, 6)}…${key.slice(-6)}`
+}
+
+// Extracts a truncated recipient key from a raw JWE body. Tries the standard
+// JWE General JSON Serialization top-level `recipients` first, then falls back
+// to the Aries DIDComm v1 Authcrypt layout (recipients inside the protected
+// header). Returns '' on any parse failure.
+export function tryExtractRecipientKeyShort(rawBody: string): string {
+  try {
+    const parsed = JSON.parse(rawBody) as Record<string, unknown>
+
+    const topRecipients = parsed.recipients
+    if (Array.isArray(topRecipients) && topRecipients.length > 0) {
+      const first = topRecipients[0] as Record<string, unknown>
+      const hdr = first.header as Record<string, unknown> | undefined
+      const kid = hdr?.kid
+      if (typeof kid === 'string' && kid.length > 0) return truncateKey(kid)
+    }
+
+    const protectedB64 = parsed.protected
+    if (typeof protectedB64 !== 'string') return ''
+    const headerStr = Buffer.from(protectedB64, 'base64').toString('utf8')
+    const header = JSON.parse(headerStr) as Record<string, unknown>
+    const innerRecipients = header.recipients
+    if (!Array.isArray(innerRecipients) || innerRecipients.length === 0) return ''
+    const first = innerRecipients[0] as Record<string, unknown>
+    const hdr = first.header as Record<string, unknown> | undefined
+    const kid = hdr?.kid
+    if (typeof kid === 'string') return truncateKey(kid)
+    return ''
+  } catch {
+    return ''
+  }
+}
+
+// Extracts the JWE top-level `iv` field as a per-message fingerprint. The `iv`
+// is unique per encryption (JWE spec) and visible at both ends of every hop
+// without decryption — unlike DIDComm v1 `@id`, which lives inside the
+// encrypted payload. Accepts either a parsed object or a raw JSON string.
+export function tryExtractJweFp(payload: unknown): string {
+  try {
+    const parsed: Record<string, unknown> =
+      typeof payload === 'string'
+        ? (JSON.parse(payload) as Record<string, unknown>)
+        : (payload as Record<string, unknown>)
+    const iv = parsed?.iv
+    return typeof iv === 'string' ? iv : ''
+  } catch {
+    return ''
+  }
+}

--- a/apps/mediator/src/logger/StructuredLogger.ts
+++ b/apps/mediator/src/logger/StructuredLogger.ts
@@ -52,6 +52,14 @@ export interface StructuredLogLine {
 
 const TASK_HOST = process.env.ECS_CONTAINER_METADATA_URI ? process.env.HOSTNAME || os.hostname() : os.hostname()
 
+// Returns true if a line at `level` would be emitted by emitStructured.
+// Use this to guard expensive field computation (e.g. JSON.parse) before
+// building the log line, so turning off debug-level logging avoids the
+// per-message parsing cost entirely.
+export function isStructuredEnabled(level: LogLevel): boolean {
+  return level >= getDebugLogLevel()
+}
+
 // Emit a structured instrumentation line to stdout (captured by the log
 // aggregator). Gated behind the runtime-toggleable debug level so it can be
 // silenced outside a debug window without a redeploy.

--- a/apps/mediator/src/logger/replaceError.test.ts
+++ b/apps/mediator/src/logger/replaceError.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { createSafeJsonReplacer } from './replaceError.js'
+
+describe('createSafeJsonReplacer', () => {
+  test('serializes errors with circular response data', () => {
+    const error = new Error('Provisioned throughput exceeded')
+    error.name = 'ProvisionedThroughputExceededException'
+
+    const response: Record<string, unknown> = {}
+    const request = { res: response }
+    response.req = request
+    Object.assign(error, { response })
+
+    const serialized = JSON.parse(JSON.stringify({ error }, createSafeJsonReplacer(), 2))
+
+    expect(serialized.error).toEqual({
+      name: 'ProvisionedThroughputExceededException',
+      message: 'Provisioned throughput exceeded',
+      stack: expect.any(String),
+      response: {
+        req: {
+          res: '[Circular]',
+        },
+      },
+    })
+  })
+})

--- a/apps/mediator/src/logger/replaceError.ts
+++ b/apps/mediator/src/logger/replaceError.ts
@@ -15,3 +15,17 @@ export function replaceError(_: unknown, value: unknown) {
 
   return value
 }
+
+export function createSafeJsonReplacer() {
+  const seen = new WeakSet<object>()
+
+  return (key: unknown, value: unknown) => {
+    if (value && typeof value === 'object') {
+      if (seen.has(value)) return '[Circular]'
+
+      seen.add(value)
+    }
+
+    return replaceError(key, value)
+  }
+}

--- a/apps/mediator/src/message-delivery/CoordinatedMediatorService.ts
+++ b/apps/mediator/src/message-delivery/CoordinatedMediatorService.ts
@@ -1,0 +1,35 @@
+import { EventEmitter, InjectionSymbols, inject, injectable, type Logger } from '@credo-ts/core'
+import {
+  DidCommConnectionService,
+  type DidCommForwardMessage,
+  type DidCommInboundMessageContext,
+  DidCommMediationRepository,
+  DidCommMediatorRoutingRepository,
+  DidCommMediatorService,
+} from '@credo-ts/didcomm'
+
+import { runInForwardDeliveryContext } from './forwardDeliveryContext.js'
+
+/**
+ * Marks queue events emitted by Credo's forward-message path. In
+ * QueueAndLiveModeDelivery, Credo owns the subsequent local delivery, so the
+ * Redis queue-event listener can avoid racing the exact same queue read/send.
+ */
+@injectable()
+export class CoordinatedMediatorService extends DidCommMediatorService {
+  public constructor(
+    mediationRepository: DidCommMediationRepository,
+    mediatorRoutingRepository: DidCommMediatorRoutingRepository,
+    eventEmitter: EventEmitter,
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    connectionService: DidCommConnectionService
+  ) {
+    super(mediationRepository, mediatorRoutingRepository, eventEmitter, logger, connectionService)
+  }
+
+  public override processForwardMessage(
+    messageContext: DidCommInboundMessageContext<DidCommForwardMessage>
+  ): Promise<void> {
+    return runInForwardDeliveryContext(() => super.processForwardMessage(messageContext))
+  }
+}

--- a/apps/mediator/src/message-delivery/KeyedSingleFlight.test.ts
+++ b/apps/mediator/src/message-delivery/KeyedSingleFlight.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest'
+import { KeyedSingleFlight } from './KeyedSingleFlight.js'
+
+function deferred() {
+  let resolve!: () => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
+}
+
+describe('KeyedSingleFlight', () => {
+  test('coalesces a synchronous burst into one run', async () => {
+    let taskCalls = 0
+    const singleFlight = new KeyedSingleFlight(async () => {
+      taskCalls += 1
+      return taskCalls
+    })
+
+    const first = singleFlight.schedule('connection-1')
+    const second = singleFlight.schedule('connection-1')
+    const third = singleFlight.schedule('connection-1')
+
+    expect(second).toBe(first)
+    expect(third).toBe(first)
+    await expect(first).resolves.toBe(1)
+    expect(taskCalls).toBe(1)
+  })
+
+  test('serializes a connection and coalesces concurrent triggers into one follow-up', async () => {
+    const firstRunStarted = deferred()
+    const releaseFirstRun = deferred()
+    let activeTasks = 0
+    let maximumActiveTasks = 0
+    let taskCalls = 0
+
+    const singleFlight = new KeyedSingleFlight(async () => {
+      taskCalls += 1
+      activeTasks += 1
+      maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks)
+
+      if (taskCalls === 1) {
+        firstRunStarted.resolve()
+        await releaseFirstRun.promise
+      }
+
+      activeTasks -= 1
+      return taskCalls
+    })
+
+    const first = singleFlight.schedule('connection-1')
+    await firstRunStarted.promise
+    const second = singleFlight.schedule('connection-1')
+    const third = singleFlight.schedule('connection-1')
+
+    expect(second).toBe(first)
+    expect(third).toBe(first)
+
+    releaseFirstRun.resolve()
+    await expect(first).resolves.toBe(2)
+    expect(taskCalls).toBe(2)
+    expect(maximumActiveTasks).toBe(1)
+  })
+
+  test('runs different connections concurrently', async () => {
+    const bothRunsStarted = deferred()
+    const releaseRuns = deferred()
+    let activeTasks = 0
+    let maximumActiveTasks = 0
+
+    const singleFlight = new KeyedSingleFlight(async (connectionId: string) => {
+      activeTasks += 1
+      maximumActiveTasks = Math.max(maximumActiveTasks, activeTasks)
+      if (activeTasks === 2) bothRunsStarted.resolve()
+
+      await releaseRuns.promise
+      activeTasks -= 1
+      return connectionId
+    })
+
+    const first = singleFlight.schedule('connection-1')
+    const second = singleFlight.schedule('connection-2')
+    await bothRunsStarted.promise
+
+    expect(maximumActiveTasks).toBe(2)
+    releaseRuns.resolve()
+    await expect(Promise.all([first, second])).resolves.toEqual(['connection-1', 'connection-2'])
+  })
+
+  test('clears a failed flight so a later trigger can retry', async () => {
+    let shouldFail = true
+    const singleFlight = new KeyedSingleFlight(async () => {
+      if (shouldFail) throw new Error('delivery failed')
+      return 'delivered'
+    })
+
+    await expect(singleFlight.schedule('connection-1')).rejects.toThrow('delivery failed')
+
+    shouldFail = false
+    await expect(singleFlight.schedule('connection-1')).resolves.toBe('delivered')
+  })
+})

--- a/apps/mediator/src/message-delivery/KeyedSingleFlight.ts
+++ b/apps/mediator/src/message-delivery/KeyedSingleFlight.ts
@@ -1,0 +1,62 @@
+interface FlightState<Result> {
+  pending: boolean
+  promise: Promise<Result>
+  started: boolean
+}
+
+/**
+ * Runs at most one task per key at a time. Triggers received while a task is
+ * running are coalesced into one follow-up run, preventing both concurrent
+ * delivery and a lost wake-up when a new queue item arrives mid-delivery.
+ */
+export class KeyedSingleFlight<Key, Result> {
+  private readonly flights = new Map<Key, FlightState<Result>>()
+
+  public constructor(private readonly task: (key: Key) => Promise<Result>) {}
+
+  public schedule(key: Key): Promise<Result> {
+    const existingFlight = this.flights.get(key)
+    if (existingFlight) {
+      // Calls made before the task starts are part of the same burst and need
+      // only one queue drain. Once a drain has started, retain one follow-up so
+      // a message queued after its read cannot be stranded.
+      if (existingFlight.started) existingFlight.pending = true
+      return existingFlight.promise
+    }
+
+    let resolveFlight!: (result: Result | PromiseLike<Result>) => void
+    let rejectFlight!: (reason?: unknown) => void
+    const promise = new Promise<Result>((resolve, reject) => {
+      resolveFlight = resolve
+      rejectFlight = reject
+    })
+    const flight = { pending: true, promise, started: false }
+    this.flights.set(key, flight)
+
+    // Start in the next microtask so a synchronous burst for one key collapses
+    // into the initial run. The fully initialized flight is visible before
+    // task() can schedule more work for the same key.
+    queueMicrotask(() => {
+      void this.drain(key, flight).then(resolveFlight, rejectFlight)
+    })
+    return flight.promise
+  }
+
+  private async drain(key: Key, flight: FlightState<Result>): Promise<Result> {
+    let result: Result
+
+    try {
+      flight.started = true
+      do {
+        flight.pending = false
+        result = await this.task(key)
+      } while (flight.pending)
+
+      return result
+    } finally {
+      if (this.flights.get(key) === flight) {
+        this.flights.delete(key)
+      }
+    }
+  }
+}

--- a/apps/mediator/src/message-delivery/deliveryOwnership.test.ts
+++ b/apps/mediator/src/message-delivery/deliveryOwnership.test.ts
@@ -1,0 +1,39 @@
+import { DidCommMessageForwardingStrategy } from '@credo-ts/didcomm'
+import { describe, expect, test } from 'vitest'
+import { shouldCredoOwnLocalDelivery } from './deliveryOwnership.js'
+
+describe('shouldCredoOwnLocalDelivery', () => {
+  test('assigns only local QueueAndLive forward events to Credo', () => {
+    expect(
+      shouldCredoOwnLocalDelivery({
+        forwardingStrategy: DidCommMessageForwardingStrategy.QueueAndLiveModeDelivery,
+        hasLocalSession: true,
+        isForwardQueueEvent: true,
+      })
+    ).toBe(true)
+
+    expect(
+      shouldCredoOwnLocalDelivery({
+        forwardingStrategy: DidCommMessageForwardingStrategy.QueueAndLiveModeDelivery,
+        hasLocalSession: true,
+        isForwardQueueEvent: false,
+      })
+    ).toBe(false)
+
+    expect(
+      shouldCredoOwnLocalDelivery({
+        forwardingStrategy: DidCommMessageForwardingStrategy.QueueOnly,
+        hasLocalSession: true,
+        isForwardQueueEvent: true,
+      })
+    ).toBe(false)
+
+    expect(
+      shouldCredoOwnLocalDelivery({
+        forwardingStrategy: DidCommMessageForwardingStrategy.QueueAndLiveModeDelivery,
+        hasLocalSession: false,
+        isForwardQueueEvent: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/mediator/src/message-delivery/deliveryOwnership.ts
+++ b/apps/mediator/src/message-delivery/deliveryOwnership.ts
@@ -1,0 +1,17 @@
+import { DidCommMessageForwardingStrategy } from '@credo-ts/didcomm'
+
+export function shouldCredoOwnLocalDelivery({
+  forwardingStrategy,
+  hasLocalSession,
+  isForwardQueueEvent,
+}: {
+  forwardingStrategy: DidCommMessageForwardingStrategy
+  hasLocalSession: boolean
+  isForwardQueueEvent: boolean
+}): boolean {
+  return (
+    forwardingStrategy === DidCommMessageForwardingStrategy.QueueAndLiveModeDelivery &&
+    isForwardQueueEvent &&
+    hasLocalSession
+  )
+}

--- a/apps/mediator/src/message-delivery/forwardDeliveryContext.test.ts
+++ b/apps/mediator/src/message-delivery/forwardDeliveryContext.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'vitest'
+import { isInForwardDeliveryContext, runInForwardDeliveryContext } from './forwardDeliveryContext.js'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+describe('forwardDeliveryContext', () => {
+  test('is scoped to the forward-delivery asynchronous call chain', async () => {
+    const contextStarted = deferred()
+    const releaseContext = deferred()
+
+    expect(isInForwardDeliveryContext()).toBe(false)
+
+    const inContext = runInForwardDeliveryContext(async () => {
+      expect(isInForwardDeliveryContext()).toBe(true)
+      contextStarted.resolve()
+      await releaseContext.promise
+      expect(isInForwardDeliveryContext()).toBe(true)
+    })
+
+    await contextStarted.promise
+    expect(isInForwardDeliveryContext()).toBe(false)
+
+    releaseContext.resolve()
+    await inContext
+    expect(isInForwardDeliveryContext()).toBe(false)
+  })
+})

--- a/apps/mediator/src/message-delivery/forwardDeliveryContext.ts
+++ b/apps/mediator/src/message-delivery/forwardDeliveryContext.ts
@@ -1,0 +1,14 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+// This context is deliberately limited to ownership of the synchronous queue
+// event emitted by processForwardMessage. It does not carry request data or
+// correlate messages across transports.
+const forwardDeliveryContext = new AsyncLocalStorage<boolean>()
+
+export function runInForwardDeliveryContext<T>(callback: () => T): T {
+  return forwardDeliveryContext.run(true, callback)
+}
+
+export function isInForwardDeliveryContext(): boolean {
+  return forwardDeliveryContext.getStore() === true
+}

--- a/apps/mediator/src/multi-instance/redis-stream-message-publishing/redisStreamMessagePublishing.test.ts
+++ b/apps/mediator/src/multi-instance/redis-stream-message-publishing/redisStreamMessagePublishing.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test, vi } from 'vitest'
+import { RedisStreamMessagePublishing } from './redisStreamMessagePublishing.js'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+
+  return { promise, resolve }
+}
+
+describe('RedisStreamMessagePublishing', () => {
+  test('processes a read batch concurrently and acknowledges every successful entry', async () => {
+    const abortController = new AbortController()
+    const bothHandlersStarted = deferred()
+    const releaseHandlers = deferred()
+    let activeHandlers = 0
+    let maximumActiveHandlers = 0
+
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    }
+    const agent = {
+      config: { logger },
+      context: { config: { logger } },
+      events: { on: vi.fn() },
+    }
+    const client = {
+      xack: vi.fn().mockResolvedValue(1),
+      xgroup: vi.fn().mockResolvedValue('OK'),
+      xreadgroup: vi.fn().mockResolvedValue([
+        [
+          'server:server-1:message-publishing',
+          [
+            ['1-0', ['message', JSON.stringify({ connectionId: 'connection-1' })]],
+            ['2-0', ['message', JSON.stringify({ connectionId: 'connection-2' })]],
+          ],
+        ],
+      ]),
+    }
+    const publishing = new RedisStreamMessagePublishing(agent as never, client as never, 'server-1')
+
+    const listening = publishing.listenForMessages(
+      async () => {
+        activeHandlers += 1
+        maximumActiveHandlers = Math.max(maximumActiveHandlers, activeHandlers)
+        if (activeHandlers === 2) {
+          abortController.abort()
+          bothHandlersStarted.resolve()
+        }
+
+        await releaseHandlers.promise
+        activeHandlers -= 1
+      },
+      { signal: abortController.signal }
+    )
+
+    await bothHandlersStarted.promise
+    expect(maximumActiveHandlers).toBe(2)
+
+    releaseHandlers.resolve()
+    await listening
+
+    expect(client.xack).toHaveBeenCalledTimes(2)
+    expect(client.xack).toHaveBeenCalledWith('server:server-1:message-publishing', 'default', '1-0')
+    expect(client.xack).toHaveBeenCalledWith('server:server-1:message-publishing', 'default', '2-0')
+  })
+
+  test('does not let one failed entry block acknowledgement of another entry', async () => {
+    const abortController = new AbortController()
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    }
+    const agent = {
+      config: { logger },
+      context: { config: { logger } },
+      events: { on: vi.fn() },
+    }
+    const client = {
+      xack: vi.fn().mockResolvedValue(1),
+      xgroup: vi.fn().mockResolvedValue('OK'),
+      xreadgroup: vi.fn().mockResolvedValue([
+        [
+          'server:server-1:message-publishing',
+          [
+            ['1-0', ['message', JSON.stringify({ connectionId: 'connection-1' })]],
+            ['2-0', ['message', JSON.stringify({ connectionId: 'connection-2' })]],
+          ],
+        ],
+      ]),
+    }
+    const publishing = new RedisStreamMessagePublishing(agent as never, client as never, 'server-1')
+
+    await publishing.listenForMessages(
+      async (message) => {
+        if (message.id === '1-0') throw new Error('delivery failed')
+        abortController.abort()
+      },
+      { signal: abortController.signal }
+    )
+
+    expect(client.xack).toHaveBeenCalledOnce()
+    expect(client.xack).toHaveBeenCalledWith('server:server-1:message-publishing', 'default', '2-0')
+    expect(logger.error).toHaveBeenCalledWith('Error processing message 1-0:', {
+      error: expect.objectContaining({ message: 'delivery failed' }),
+    })
+  })
+})

--- a/apps/mediator/src/multi-instance/redis-stream-message-publishing/redisStreamMessagePublishing.ts
+++ b/apps/mediator/src/multi-instance/redis-stream-message-publishing/redisStreamMessagePublishing.ts
@@ -118,14 +118,16 @@ export class RedisStreamMessagePublishing {
         }
 
         const messages = this.parseStreamMessages(response)
-        for (const message of messages) {
-          try {
-            await handler(message)
-            await this.acknowledgeMessage(streamKey, message.id)
-          } catch (error) {
-            this.agent.config.logger.error(`Error processing message ${message.id}:`, { error })
-          }
-        }
+        await Promise.all(
+          messages.map(async (message) => {
+            try {
+              await handler(message)
+              await this.acknowledgeMessage(streamKey, message.id)
+            } catch (error) {
+              this.agent.config.logger.error(`Error processing message ${message.id}:`, { error })
+            }
+          })
+        )
       } catch (error) {
         this.agent.config.logger.error('Error reading from stream', { error })
       }

--- a/apps/mediator/src/storage/MessageRepository.ts
+++ b/apps/mediator/src/storage/MessageRepository.ts
@@ -26,12 +26,18 @@ export class MessageRepository extends Repository<MessageRecord> {
 
   // Aggregate queue-depth stats for the 10s gauge snapshot. Only used by the
   // in-tree `credo` pickup backend (debug instrumentation, best-effort).
+  //
+  // Bounded to 500 records to avoid a full-table scan on a large backlog:
+  // `getAll()` hydrates every row through the storage layer on the same path
+  // whose latency the gauge is diagnosing. `total` reflects the sample size
+  // (accurate for queues ≤ 500; capped at 500 beyond that).
   public async getQueueStats(agentContext: AgentContext): Promise<{
     total: number
     oldestAgeMs: number
     top10: Array<{ connId: string; count: number }>
   }> {
-    const records = await this.getAll(agentContext)
+    const SAMPLE_LIMIT = 500
+    const records = await this.findByQuery(agentContext, {}, { limit: SAMPLE_LIMIT })
 
     let oldest = Date.now()
     const connCounts: Record<string, number> = {}

--- a/apps/mediator/src/storage/MessageRepository.ts
+++ b/apps/mediator/src/storage/MessageRepository.ts
@@ -23,4 +23,34 @@ export class MessageRepository extends Repository<MessageRecord> {
   public findByConnectionId(agentContext: AgentContext, connectionId: string) {
     return this.findByQuery(agentContext, { connectionId })
   }
+
+  // Aggregate queue-depth stats for the 10s gauge snapshot. Only used by the
+  // in-tree `credo` pickup backend (debug instrumentation, best-effort).
+  public async getQueueStats(agentContext: AgentContext): Promise<{
+    total: number
+    oldestAgeMs: number
+    top10: Array<{ connId: string; count: number }>
+  }> {
+    const records = await this.getAll(agentContext)
+
+    let oldest = Date.now()
+    const connCounts: Record<string, number> = {}
+
+    for (const record of records) {
+      if (record.createdAt.getTime() < oldest) oldest = record.createdAt.getTime()
+      const connId = record.connectionId ?? 'unknown'
+      connCounts[connId] = (connCounts[connId] ?? 0) + 1
+    }
+
+    const top10 = Object.entries(connCounts)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([connId, count]) => ({ connId, count }))
+
+    return {
+      total: records.length,
+      oldestAgeMs: records.length > 0 ? Date.now() - oldest : 0,
+      top10,
+    }
+  }
 }

--- a/apps/mediator/src/storage/StorageMessageQueue.ts
+++ b/apps/mediator/src/storage/StorageMessageQueue.ts
@@ -12,6 +12,12 @@ import { MessageRecord } from './MessageRecord.js'
 import { MessageRepository } from './MessageRepository.js'
 
 export class StorageServiceMessageQueue implements DidCommQueueTransportRepository {
+  // Aggregate queue-depth stats for the gauge snapshot (debug instrumentation).
+  public async getQueueStats(agentContext: AgentContext) {
+    const messageRepository = agentContext.resolve(MessageRepository)
+    return messageRepository.getQueueStats(agentContext)
+  }
+
   public async getAvailableMessageCount(agentContext: AgentContext, options: GetAvailableMessageCountOptions) {
     const { connectionId } = options
 

--- a/apps/mediator/src/transports/InstrumentedHttpOutboundTransport.ts
+++ b/apps/mediator/src/transports/InstrumentedHttpOutboundTransport.ts
@@ -1,0 +1,54 @@
+import { LogLevel } from '@credo-ts/core'
+import { DidCommHttpOutboundTransport, type DidCommOutboundPackage } from '@credo-ts/didcomm'
+import { recordOutboundMs } from '../instrumentation/metrics.js'
+import { durationMs, emitStructured, makeSpanId, monoNow, tryExtractJweFp } from '../logger/StructuredLogger.js'
+
+// HTTP outbound to the agent-controller. Times each send and records the
+// latency into the outbound p50/p95 gauge (confirms/refutes mediator→controller
+// back-pressure, hypothesis H2 in the debug plan). jwe_fp here (the inner iv for
+// forwarded traffic) joins to the recipient side and to mediator.forward.bridge.
+export class InstrumentedHttpOutboundTransport extends DidCommHttpOutboundTransport {
+  public async sendMessage(outboundPackage: DidCommOutboundPackage): Promise<void> {
+    const spanId = makeSpanId()
+    const startMono = monoNow()
+    const targetUrl = outboundPackage.endpoint ?? ''
+    const jweFp = tryExtractJweFp(outboundPackage.payload)
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.outbound.send.start',
+      span_id: spanId,
+      jwe_fp: jweFp,
+      conn_id: outboundPackage.connectionId ?? '',
+      target_url: targetUrl,
+    })
+
+    try {
+      await super.sendMessage(outboundPackage)
+      const elapsed = durationMs(startMono)
+      recordOutboundMs(elapsed)
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.outbound.send.end',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        conn_id: outboundPackage.connectionId ?? '',
+        target_url: targetUrl,
+        duration_ms: elapsed,
+        status: 'ok',
+      })
+    } catch (err) {
+      const elapsed = durationMs(startMono)
+      recordOutboundMs(elapsed)
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.outbound.send.end',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        conn_id: outboundPackage.connectionId ?? '',
+        target_url: targetUrl,
+        duration_ms: elapsed,
+        status: 'error',
+        notes: err instanceof Error ? err.message.slice(0, 120) : 'unknown error',
+      })
+      throw err
+    }
+  }
+}

--- a/apps/mediator/src/transports/InstrumentedTransportService.ts
+++ b/apps/mediator/src/transports/InstrumentedTransportService.ts
@@ -1,0 +1,87 @@
+import { AgentContext, injectable, LogLevel } from '@credo-ts/core'
+import { type DidCommEncryptedMessage, DidCommTransportService, type DidCommTransportSession } from '@credo-ts/didcomm'
+
+import { durationMs, emitStructured, makeSpanId, monoNow, tryExtractJweFp } from '../logger/StructuredLogger.js'
+
+// Captures the LIVE-mode delivery path that no outbound transport ever sees.
+//
+// For the default DirectDelivery strategy, the mediator forward path
+// (DidCommMessageSender.sendPackage) first tries an existing inbound transport
+// session — `transportService.findSessionByConnectionId(conn).send(...)` — and
+// returns on success WITHOUT touching any outbound transport. So the fast,
+// common live delivery to a connected mobile wallet is invisible to
+// InstrumentedWsOutboundTransport (which only fires on the rarer
+// service-endpoint dial-out). QueueAndLiveModeDelivery's pickup delivery
+// ultimately pushes over the same session.send too.
+//
+// We wrap each session's `send` at saveSession() time — the single chokepoint
+// through which every live delivery passes, regardless of forwarding strategy —
+// and emit mediator.live.delivery.start/end around it. The jwe_fp is the inner
+// iv being delivered; it joins to the recipient's inbound and to the outer iv
+// via mediator.forward.bridge.
+//
+// This subclass is registered on the DidCommTransportService DI token (see
+// agent.ts) only when instrumentation is enabled; otherwise the stock service
+// is used unchanged.
+
+interface InstrumentedSession extends DidCommTransportSession {
+  __sendInstrumented?: boolean
+}
+
+@injectable()
+export class InstrumentedTransportService extends DidCommTransportService {
+  public override saveSession(session: DidCommTransportSession): void {
+    this.instrumentSessionSend(session as InstrumentedSession)
+    super.saveSession(session)
+  }
+
+  private instrumentSessionSend(session: InstrumentedSession): void {
+    // saveSession can be called repeatedly for the same session object (e.g.
+    // setConnectionIdForSession re-saves) — wrap send exactly once.
+    if (session.__sendInstrumented) return
+    session.__sendInstrumented = true
+
+    const originalSend = session.send.bind(session)
+    session.send = async (agentContext: AgentContext, encryptedMessage: DidCommEncryptedMessage): Promise<void> => {
+      const spanId = makeSpanId()
+      const startMono = monoNow()
+      const jweFp = tryExtractJweFp(encryptedMessage)
+
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.live.delivery.start',
+        flow: 'pickup',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        conn_id: session.connectionId ?? '',
+        transport_session_id: session.id,
+      })
+
+      try {
+        await originalSend(agentContext, encryptedMessage)
+        emitStructured(LogLevel.info, {
+          hop: 'mediator.live.delivery.end',
+          flow: 'pickup',
+          span_id: spanId,
+          jwe_fp: jweFp,
+          conn_id: session.connectionId ?? '',
+          transport_session_id: session.id,
+          duration_ms: durationMs(startMono),
+          status: 'ok',
+        })
+      } catch (err) {
+        emitStructured(LogLevel.info, {
+          hop: 'mediator.live.delivery.end',
+          flow: 'pickup',
+          span_id: spanId,
+          jwe_fp: jweFp,
+          conn_id: session.connectionId ?? '',
+          transport_session_id: session.id,
+          duration_ms: durationMs(startMono),
+          status: 'error',
+          notes: err instanceof Error ? err.message.slice(0, 120) : 'unknown error',
+        })
+        throw err
+      }
+    }
+  }
+}

--- a/apps/mediator/src/transports/InstrumentedWsOutboundTransport.ts
+++ b/apps/mediator/src/transports/InstrumentedWsOutboundTransport.ts
@@ -1,0 +1,58 @@
+import { LogLevel } from '@credo-ts/core'
+import { type DidCommOutboundPackage, DidCommWsOutboundTransport } from '@credo-ts/didcomm'
+
+import { durationMs, emitStructured, makeSpanId, monoNow, tryExtractJweFp } from '../logger/StructuredLogger.js'
+
+// WS outbound is only used to push to mobile wallet recipients (the controller
+// is reached over HTTP). Every send here is therefore a live-mode delivery, so
+// it doubles as the `forward.strategy.decision = live` log point. jwe_fp is the
+// inner iv being delivered — it joins to the recipient's inbound and to the
+// outer iv via the mediator.forward.bridge line.
+export class InstrumentedWsOutboundTransport extends DidCommWsOutboundTransport {
+  public async sendMessage(outboundPackage: DidCommOutboundPackage): Promise<void> {
+    const spanId = makeSpanId()
+    const startMono = monoNow()
+    const targetUrl = outboundPackage.endpoint ?? ''
+    const jweFp = tryExtractJweFp(outboundPackage.payload)
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.forward.strategy.decision',
+      conn_id: outboundPackage.connectionId ?? '',
+      jwe_fp: jweFp,
+      decision: 'live',
+    })
+
+    emitStructured(LogLevel.info, {
+      hop: 'mediator.live.delivery.start',
+      span_id: spanId,
+      jwe_fp: jweFp,
+      conn_id: outboundPackage.connectionId ?? '',
+      target_url: targetUrl,
+    })
+
+    try {
+      await super.sendMessage(outboundPackage)
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.live.delivery.end',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        conn_id: outboundPackage.connectionId ?? '',
+        target_url: targetUrl,
+        duration_ms: durationMs(startMono),
+        status: 'ok',
+      })
+    } catch (err) {
+      emitStructured(LogLevel.info, {
+        hop: 'mediator.live.delivery.end',
+        span_id: spanId,
+        jwe_fp: jweFp,
+        conn_id: outboundPackage.connectionId ?? '',
+        target_url: targetUrl,
+        duration_ms: durationMs(startMono),
+        status: 'error',
+        notes: err instanceof Error ? err.message.slice(0, 120) : 'unknown error',
+      })
+      throw err
+    }
+  }
+}

--- a/apps/mediator/src/transports/InstrumentedWsOutboundTransport.ts
+++ b/apps/mediator/src/transports/InstrumentedWsOutboundTransport.ts
@@ -1,13 +1,18 @@
 import { LogLevel } from '@credo-ts/core'
 import { type DidCommOutboundPackage, DidCommWsOutboundTransport } from '@credo-ts/didcomm'
 
+import { recordOutboundMs } from '../instrumentation/metrics.js'
 import { durationMs, emitStructured, makeSpanId, monoNow, tryExtractJweFp } from '../logger/StructuredLogger.js'
 
-// WS outbound is only used to push to mobile wallet recipients (the controller
-// is reached over HTTP). Every send here is therefore a live-mode delivery, so
-// it doubles as the `forward.strategy.decision = live` log point. jwe_fp is the
-// inner iv being delivered — it joins to the recipient's inbound and to the
-// outer iv via the mediator.forward.bridge line.
+// WS *outbound* transport: used only when the mediator dials OUT to a WS service
+// endpoint (the rarer service-endpoint branch of sendPackage). This is NOT the
+// common live-delivery path — live delivery to a connected mobile wallet reuses
+// the existing inbound WS session via session.send(), which is instrumented in
+// InstrumentedTransportService (mediator.live.delivery.*). Emitting the same
+// neutral mediator.outbound.send.* hops as InstrumentedHttpOutboundTransport
+// keeps the two outbound transports symmetric and feeds the outbound p50/p95
+// gauge. jwe_fp is the inner iv being delivered — it joins to the recipient's
+// inbound and to the outer iv via mediator.forward.bridge.
 export class InstrumentedWsOutboundTransport extends DidCommWsOutboundTransport {
   public async sendMessage(outboundPackage: DidCommOutboundPackage): Promise<void> {
     const spanId = makeSpanId()
@@ -16,14 +21,7 @@ export class InstrumentedWsOutboundTransport extends DidCommWsOutboundTransport 
     const jweFp = tryExtractJweFp(outboundPackage.payload)
 
     emitStructured(LogLevel.info, {
-      hop: 'mediator.forward.strategy.decision',
-      conn_id: outboundPackage.connectionId ?? '',
-      jwe_fp: jweFp,
-      decision: 'live',
-    })
-
-    emitStructured(LogLevel.info, {
-      hop: 'mediator.live.delivery.start',
+      hop: 'mediator.outbound.send.start',
       span_id: spanId,
       jwe_fp: jweFp,
       conn_id: outboundPackage.connectionId ?? '',
@@ -32,23 +30,27 @@ export class InstrumentedWsOutboundTransport extends DidCommWsOutboundTransport 
 
     try {
       await super.sendMessage(outboundPackage)
+      const elapsed = durationMs(startMono)
+      recordOutboundMs(elapsed)
       emitStructured(LogLevel.info, {
-        hop: 'mediator.live.delivery.end',
+        hop: 'mediator.outbound.send.end',
         span_id: spanId,
         jwe_fp: jweFp,
         conn_id: outboundPackage.connectionId ?? '',
         target_url: targetUrl,
-        duration_ms: durationMs(startMono),
+        duration_ms: elapsed,
         status: 'ok',
       })
     } catch (err) {
+      const elapsed = durationMs(startMono)
+      recordOutboundMs(elapsed)
       emitStructured(LogLevel.info, {
-        hop: 'mediator.live.delivery.end',
+        hop: 'mediator.outbound.send.end',
         span_id: spanId,
         jwe_fp: jweFp,
         conn_id: outboundPackage.connectionId ?? '',
         target_url: targetUrl,
-        duration_ms: durationMs(startMono),
+        duration_ms: elapsed,
         status: 'error',
         notes: err instanceof Error ? err.message.slice(0, 120) : 'unknown error',
       })

--- a/apps/mediator/src/transports/wsHeartbeat.ts
+++ b/apps/mediator/src/transports/wsHeartbeat.ts
@@ -1,0 +1,48 @@
+import type { WebSocket, WebSocketServer } from 'ws'
+
+interface HeartbeatSocket extends WebSocket {
+  __isAlive?: boolean
+}
+
+// Server-side WebSocket keepalive (ping/pong).
+//
+// Upstream didcomm-mediator-credo does not ship a heartbeat. Without one, an
+// idle live-mode WS to a mobile wallet can be silently dropped by an
+// intermediary idle timeout (e.g. an ALB), which tears down the Credo live
+// pickup session and forces the next message onto the slow queue+push path.
+// Periodic pings keep the connection non-idle; the mark-and-sweep terminates
+// sockets that stop answering so dead connections don't linger.
+//
+// This is protocol-level (ping/pong frames) and transparent to Credo's message
+// handling — it never touches application message frames. A generous two-miss
+// window (2 * intervalMs) avoids terminating slow-but-healthy clients.
+//
+// Returns a stop function; pass intervalMs <= 0 to disable entirely.
+export function startWsHeartbeat(socketServer: WebSocketServer, intervalMs: number): () => void {
+  if (!intervalMs || intervalMs <= 0) return () => {}
+
+  socketServer.on('connection', (socket: HeartbeatSocket) => {
+    socket.__isAlive = true
+    socket.on('pong', () => {
+      socket.__isAlive = true
+    })
+  })
+
+  const timer = setInterval(() => {
+    for (const client of socketServer.clients as Set<HeartbeatSocket>) {
+      if (client.__isAlive === false) {
+        client.terminate()
+        continue
+      }
+      client.__isAlive = false
+      try {
+        client.ping()
+      } catch {
+        // socket already closing — sweep will collect it next tick
+      }
+    }
+  }, intervalMs)
+  if (timer.unref) timer.unref()
+
+  return () => clearInterval(timer)
+}

--- a/apps/mediator/src/transports/wsHeartbeat.ts
+++ b/apps/mediator/src/transports/wsHeartbeat.ts
@@ -1,7 +1,7 @@
 import type { WebSocket, WebSocketServer } from 'ws'
 
 interface HeartbeatSocket extends WebSocket {
-  __isAlive?: boolean
+  __missedPongs?: number
 }
 
 // Server-side WebSocket keepalive (ping/pong).
@@ -14,27 +14,31 @@ interface HeartbeatSocket extends WebSocket {
 // sockets that stop answering so dead connections don't linger.
 //
 // This is protocol-level (ping/pong frames) and transparent to Credo's message
-// handling — it never touches application message frames. A generous two-miss
-// window (2 * intervalMs) avoids terminating slow-but-healthy clients.
+// handling — it never touches application message frames. A two-miss window
+// (2 × intervalMs without a pong) avoids terminating slow-but-healthy clients
+// on a single transient network hiccup.
 //
 // Returns a stop function; pass intervalMs <= 0 to disable entirely.
 export function startWsHeartbeat(socketServer: WebSocketServer, intervalMs: number): () => void {
   if (!intervalMs || intervalMs <= 0) return () => {}
 
   socketServer.on('connection', (socket: HeartbeatSocket) => {
-    socket.__isAlive = true
+    socket.__missedPongs = 0
     socket.on('pong', () => {
-      socket.__isAlive = true
+      socket.__missedPongs = 0
     })
   })
 
   const timer = setInterval(() => {
     for (const client of socketServer.clients as Set<HeartbeatSocket>) {
-      if (client.__isAlive === false) {
+      const missed = client.__missedPongs ?? 0
+      if (missed >= 2) {
         client.terminate()
         continue
       }
-      client.__isAlive = false
+      // Increment before ping so that if no pong arrives by the next tick,
+      // the counter reflects one additional miss.
+      client.__missedPongs = missed + 1
       try {
         client.ping()
       } catch {

--- a/packages/transport-queue-dynamodb/src/TransportQueueDynamoDb.ts
+++ b/packages/transport-queue-dynamodb/src/TransportQueueDynamoDb.ts
@@ -9,22 +9,39 @@ import {
 } from '@credo-ts/didcomm'
 import { DynamoDbClientRepository, DynamoDbClientRepositoryOptions } from './client.js'
 
+export type DynamoDbTransportQueueOptions = DynamoDbClientRepositoryOptions & {
+  /**
+   * @default 10
+   */
+  maximumMessageCount?: number
+}
+
 export class DidCommTransportQueueDynamoDb implements DidCommQueueTransportRepository {
   private client: DynamoDbClientRepository
+  private maximumMessageCount: number
 
-  private constructor(client: DynamoDbClientRepository) {
+  private constructor(client: DynamoDbClientRepository, maximumMessageCount: number) {
     this.client = client
+    this.maximumMessageCount = maximumMessageCount
   }
 
-  public static async initialize(options: DynamoDbClientRepositoryOptions) {
-    return new DidCommTransportQueueDynamoDb(await DynamoDbClientRepository.initialize(options))
+  public static async initialize(options: DynamoDbTransportQueueOptions) {
+    const { maximumMessageCount = 10, ...clientOptions } = options
+    if (!Number.isInteger(maximumMessageCount) || maximumMessageCount < 1) {
+      throw new Error('maximumMessageCount must be a positive integer')
+    }
+
+    return new DidCommTransportQueueDynamoDb(
+      await DynamoDbClientRepository.initialize(clientOptions),
+      maximumMessageCount
+    )
   }
 
   public async getAvailableMessageCount(
     _agentContext: AgentContext,
-    { connectionId }: GetAvailableMessageCountOptions
+    { connectionId, recipientDid }: GetAvailableMessageCountOptions
   ): Promise<number> {
-    return await this.client.getMessageCount(connectionId)
+    return await this.client.getMessageCount(connectionId, recipientDid, this.maximumMessageCount)
   }
 
   public async takeFromQueue(

--- a/packages/transport-queue-dynamodb/src/client.ts
+++ b/packages/transport-queue-dynamodb/src/client.ts
@@ -10,8 +10,6 @@ import {
   DynamoDBClientConfigType,
   QueryCommand,
   QueryCommandInput,
-  ScanCommand,
-  ScanCommandInput,
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
@@ -73,12 +71,67 @@ export class DynamoDbClientRepository {
     } catch (error) {
       // Already exists
       if (error instanceof Error && error.name === 'ResourceInUseException') {
+        await dcr.validateTableKeySchema()
         return dcr
       }
       throw error
     }
 
     return dcr
+  }
+
+  private async validateTableKeySchema(): Promise<void> {
+    const response = await this.dynamodbClient.send(
+      new DescribeTableCommand({
+        TableName: this.tableName,
+      })
+    )
+
+    const actualKeySchema = response.Table?.KeySchema
+    const actualAttributeDefinitions = response.Table?.AttributeDefinitions
+    const hasExpectedKeySchema =
+      actualKeySchema?.length === keySchema.length &&
+      keySchema.every((expectedKey) =>
+        actualKeySchema.some(
+          (actualKey) =>
+            actualKey.AttributeName === expectedKey.AttributeName && actualKey.KeyType === expectedKey.KeyType
+        )
+      )
+    const hasExpectedAttributeDefinitions = attributeDefinitions.every((expectedAttribute) =>
+      actualAttributeDefinitions?.some(
+        (actualAttribute) =>
+          actualAttribute.AttributeName === expectedAttribute.AttributeName &&
+          actualAttribute.AttributeType === expectedAttribute.AttributeType
+      )
+    )
+
+    if (!hasExpectedKeySchema || !hasExpectedAttributeDefinitions) {
+      throw new Error(
+        `DynamoDB table ${this.tableName} has an incompatible schema. Expected key schema ${JSON.stringify(
+          keySchema
+        )} and attribute definitions ${JSON.stringify(attributeDefinitions)}, received key schema ${JSON.stringify(
+          actualKeySchema
+        )} and attribute definitions ${JSON.stringify(actualAttributeDefinitions)}`
+      )
+    }
+  }
+
+  private async getLatestMessageId(connectionId: string) {
+    const response = await this.dynamodbClient.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'connectionId = :connectionId',
+        ExpressionAttributeValues: {
+          ':connectionId': { S: connectionId },
+        },
+        ProjectionExpression: 'messageId',
+        Select: 'SPECIFIC_ATTRIBUTES',
+        Limit: 1,
+        ScanIndexForward: false,
+      })
+    )
+
+    return response.Items?.[0]?.messageId
   }
 
   private async waitForTableToExist(): Promise<void> {
@@ -114,20 +167,62 @@ export class DynamoDbClientRepository {
     })
   }
 
-  async getMessageCount(connectionId: string): Promise<number> {
-    const params: ScanCommandInput = {
-      TableName: this.tableName,
-      FilterExpression: 'connectionId = :connectionId',
-      ExpressionAttributeValues: {
-        ':connectionId': { S: connectionId },
-      },
-      Select: 'COUNT',
-    }
-
+  async getMessageCount(connectionId: string, recipientDid?: string, maximumCount?: number): Promise<number> {
     try {
-      const command = new ScanCommand(params)
-      const response = await this.dynamodbClient.send(command)
-      return response.Count || 0
+      const params: QueryCommandInput = {
+        TableName: this.tableName,
+        KeyConditionExpression: 'connectionId = :connectionId',
+        ExpressionAttributeValues: {
+          ':connectionId': { S: connectionId },
+        },
+        Select: 'COUNT',
+      }
+
+      if (recipientDid !== undefined) {
+        const latestMessageId = await this.getLatestMessageId(connectionId)
+        if (!latestMessageId) return 0
+
+        params.KeyConditionExpression += ' AND messageId <= :latestMessageId'
+        params.FilterExpression = 'contains(recipientDids, :recipientDid)'
+        params.ExpressionAttributeValues = {
+          ...params.ExpressionAttributeValues,
+          ':recipientDid': { S: recipientDid },
+          ':latestMessageId': latestMessageId,
+        }
+      } else {
+        params.Limit = maximumCount
+      }
+
+      let count = 0
+      let lastEvaluatedKey: QueryCommandInput['ExclusiveStartKey']
+
+      do {
+        const previousLastEvaluatedKey = lastEvaluatedKey
+        const command = new QueryCommand({
+          ...params,
+          ExclusiveStartKey: lastEvaluatedKey,
+        })
+        const response = await this.dynamodbClient.send(command)
+
+        count += response.Count || 0
+        lastEvaluatedKey = response.LastEvaluatedKey
+
+        if (maximumCount !== undefined && count >= maximumCount) {
+          return maximumCount
+        }
+
+        if (
+          lastEvaluatedKey &&
+          previousLastEvaluatedKey &&
+          JSON.stringify(lastEvaluatedKey) === JSON.stringify(previousLastEvaluatedKey)
+        ) {
+          throw new Error(
+            `DynamoDB returned a non-advancing pagination key while counting messages for connection ${connectionId}`
+          )
+        }
+      } while (lastEvaluatedKey)
+
+      return count
     } catch (error) {
       this.logger.error('Error getting entries count:', { error })
       throw error
@@ -146,37 +241,61 @@ export class DynamoDbClientRepository {
       ExpressionAttributeValues: {
         ':connectionId': { S: options.connectionId },
       },
-      Limit: options.limit,
     }
 
-    if (options.recipientDid) {
+    if (options.recipientDid !== undefined) {
+      const latestMessageId = await this.getLatestMessageId(options.connectionId)
+      if (!latestMessageId) return []
+
+      queryParams.KeyConditionExpression += ' AND messageId <= :latestMessageId'
       queryParams.FilterExpression = 'contains(recipientDids, :recipientDid)'
-
-      if (queryParams.ExpressionAttributeValues) {
-        queryParams.ExpressionAttributeValues[':recipientDid'] = { S: options.recipientDid }
+      queryParams.ExpressionAttributeValues = {
+        ...queryParams.ExpressionAttributeValues,
+        ':recipientDid': { S: options.recipientDid },
+        ':latestMessageId': latestMessageId,
       }
+    } else {
+      queryParams.Limit = options.limit
     }
 
-    const command = new QueryCommand(queryParams)
-    const response = await this.dynamodbClient.send(command)
+    const messages: QueuedMessage[] = []
+    let lastEvaluatedKey: QueryCommandInput['ExclusiveStartKey']
 
-    const messages = (response.Items?.map((item) => unmarshall(item)) || []).map(
-      (i) =>
-        ({
-          ...i,
-          receivedAt: new Date(i.receivedAt),
-          id: i.messageId.toString(),
-        }) as unknown as QueuedMessage
+    do {
+      const response = await this.dynamodbClient.send(
+        new QueryCommand({
+          ...queryParams,
+          ExclusiveStartKey: lastEvaluatedKey,
+        })
+      )
+
+      messages.push(
+        ...(response.Items?.map((item) => unmarshall(item)) || []).map(
+          (item) =>
+            ({
+              ...item,
+              receivedAt: new Date(item.receivedAt),
+              id: item.messageId.toString(),
+            }) as unknown as QueuedMessage
+        )
+      )
+      lastEvaluatedKey = response.LastEvaluatedKey
+    } while (
+      options.recipientDid !== undefined &&
+      lastEvaluatedKey &&
+      (options.limit === undefined || messages.length < options.limit)
     )
 
-    if (options.deleteMessages && messages.length > 0) {
+    const messagesToReturn = options.limit === undefined ? messages : messages.slice(0, options.limit)
+
+    if (options.deleteMessages && messagesToReturn.length > 0) {
       await this.removeMessages({
         connectionId: options.connectionId,
-        messageIds: messages.map((m) => m.id),
+        messageIds: messagesToReturn.map((m) => m.id),
       })
     }
 
-    return messages
+    return messagesToReturn
   }
 
   async addMessage(options: AddQueuedMessageOptions): Promise<string> {

--- a/packages/transport-queue-dynamodb/src/index.ts
+++ b/packages/transport-queue-dynamodb/src/index.ts
@@ -1,2 +1,3 @@
 export type { DynamoDbClientRepositoryOptions as DynamodbClientRepositoryOptions } from './client.js'
+export type { DynamoDbTransportQueueOptions } from './TransportQueueDynamoDb.js'
 export { DidCommTransportQueueDynamoDb } from './TransportQueueDynamoDb.js'

--- a/packages/transport-queue-dynamodb/tests/client.test.ts
+++ b/packages/transport-queue-dynamodb/tests/client.test.ts
@@ -138,6 +138,70 @@ suite('dynamodb client', () => {
     expect(countAfterDelete).toStrictEqual(0)
   })
 
+  test('counts messages across DynamoDB query pages', async () => {
+    const newConnectionId = 'large-connection-id'
+    const largeEncryptedMessage = {
+      ...encryptedMessage,
+      ciphertext: 'x'.repeat(300_000),
+    }
+    const ids = await Promise.all(
+      [0, 1, 2, 3].map((index) =>
+        client.addMessage({
+          connectionId: newConnectionId,
+          recipientDids,
+          encryptedMessage: largeEncryptedMessage,
+          receivedAt: new Date(index * 1000),
+        })
+      )
+    )
+
+    expect(await client.getMessageCount(newConnectionId)).toStrictEqual(4)
+    expect(await client.getMessageCount(newConnectionId, recipientDids[0])).toStrictEqual(4)
+    expect(await client.getMessageCount(newConnectionId, 'did:key:missing')).toStrictEqual(0)
+
+    await client.removeMessages({ connectionId: newConnectionId, messageIds: ids })
+  })
+
+  test('counts and takes the same recipient messages', async () => {
+    const newConnectionId = 'recipient-filter-connection-id'
+    const otherRecipientDid = 'did:key:other'
+    const targetRecipientDid = 'did:key:target'
+    const otherMessageIds = await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        client.addMessage({
+          connectionId: newConnectionId,
+          recipientDids: [otherRecipientDid],
+          encryptedMessage,
+          receivedAt: new Date(index),
+        })
+      )
+    )
+    const targetMessageIds = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        client.addMessage({
+          connectionId: newConnectionId,
+          recipientDids: [targetRecipientDid],
+          encryptedMessage,
+          receivedAt: new Date(1000 + index),
+        })
+      )
+    )
+
+    expect(await client.getMessageCount(newConnectionId, targetRecipientDid, 10)).toStrictEqual(5)
+
+    const messages = await client.getMessages({
+      connectionId: newConnectionId,
+      recipientDid: targetRecipientDid,
+      limit: 5,
+    })
+    expect(messages.map((message) => message.id)).toStrictEqual(targetMessageIds)
+
+    await client.removeMessages({
+      connectionId: newConnectionId,
+      messageIds: [...otherMessageIds, ...targetMessageIds],
+    })
+  })
+
   test('validate sorting', async () => {
     const now = new Date()
     const oneHourInThePast = new Date()

--- a/packages/transport-queue-dynamodb/tests/client.unit.test.ts
+++ b/packages/transport-queue-dynamodb/tests/client.unit.test.ts
@@ -1,0 +1,196 @@
+import { CreateTableCommand, DescribeTableCommand, DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb'
+import { AgentContext, ConsoleLogger, DependencyManager, LogLevel } from '@credo-ts/core'
+import { expect, suite, test, vi } from 'vitest'
+import { DynamoDbClientRepository } from '../src/client.js'
+import { DidCommTransportQueueDynamoDb } from '../src/TransportQueueDynamoDb.js'
+
+const connectionId = '4ffdd113-117b-4827-9af5-28aa73ec4bad'
+const recipientDid = 'did:key:123'
+const clientOptions = {
+  logger: new ConsoleLogger(LogLevel.off),
+  region: 'local',
+  credentials: {
+    accessKeyId: 'local',
+    secretAccessKey: 'local',
+  },
+}
+
+suite('dynamodb client count query', () => {
+  test('validates the key schema of an existing table', async () => {
+    const send = vi.spyOn(DynamoDBClient.prototype, 'send').mockImplementation(async (command) => {
+      if (command instanceof CreateTableCommand) {
+        throw Object.assign(new Error('Table already exists'), { name: 'ResourceInUseException' })
+      }
+
+      return {
+        Table: {
+          AttributeDefinitions: [
+            { AttributeName: 'connectionId', AttributeType: 'S' },
+            { AttributeName: 'messageId', AttributeType: 'N' },
+          ],
+          KeySchema: [
+            { AttributeName: 'connectionId', KeyType: 'HASH' },
+            { AttributeName: 'messageId', KeyType: 'RANGE' },
+          ],
+        },
+      } as never
+    })
+
+    try {
+      await expect(DynamoDbClientRepository.initialize(clientOptions)).resolves.toBeDefined()
+    } finally {
+      send.mockRestore()
+    }
+  })
+
+  test('rejects an existing table with an incompatible key schema', async () => {
+    const send = vi.spyOn(DynamoDBClient.prototype, 'send').mockImplementation(async (command) => {
+      if (command instanceof CreateTableCommand) {
+        throw Object.assign(new Error('Table already exists'), { name: 'ResourceInUseException' })
+      }
+
+      return {
+        Table: {
+          AttributeDefinitions: [
+            { AttributeName: 'connectionId', AttributeType: 'S' },
+            { AttributeName: 'messageId', AttributeType: 'S' },
+          ],
+          KeySchema: [
+            { AttributeName: 'connectionId', KeyType: 'HASH' },
+            { AttributeName: 'messageId', KeyType: 'RANGE' },
+          ],
+        },
+      } as never
+    })
+
+    try {
+      await expect(DynamoDbClientRepository.initialize(clientOptions)).rejects.toThrow('incompatible schema')
+    } finally {
+      send.mockRestore()
+    }
+  })
+
+  test('paginates exact counts and caps pickup counts at the requested maximum', async () => {
+    const lastEvaluatedKey = {
+      connectionId: { S: connectionId },
+      messageId: { N: '2' },
+    }
+    const countResponses = [
+      { Count: 2, LastEvaluatedKey: lastEvaluatedKey },
+      { Count: 3 },
+      { Count: 2, LastEvaluatedKey: lastEvaluatedKey },
+      { Count: 3 },
+    ]
+    let countQueryCount = 0
+    const send = vi.spyOn(DynamoDBClient.prototype, 'send').mockImplementation(async (command) => {
+      if (command instanceof CreateTableCommand) return {} as never
+      if (command instanceof DescribeTableCommand) return { Table: { TableStatus: 'ACTIVE' } } as never
+      if (command instanceof QueryCommand && command.input.Select === 'SPECIFIC_ATTRIBUTES') {
+        return { Items: [{ messageId: { N: '3' } }] } as never
+      }
+
+      return countResponses[countQueryCount++] as never
+    })
+
+    try {
+      const client = await DynamoDbClientRepository.initialize(clientOptions)
+
+      expect(await client.getMessageCount(connectionId)).toStrictEqual(5)
+      expect(await client.getMessageCount(connectionId, undefined, 2)).toStrictEqual(2)
+      expect(await client.getMessageCount(connectionId, recipientDid, 10)).toStrictEqual(3)
+
+      const queryCommands = send.mock.calls.filter(([command]) => command instanceof QueryCommand)
+      const firstCommand = queryCommands[0][0] as QueryCommand
+      expect(firstCommand.input).toMatchObject({
+        TableName: 'queued_messages',
+        KeyConditionExpression: 'connectionId = :connectionId',
+        ExpressionAttributeValues: {
+          ':connectionId': { S: connectionId },
+        },
+        Select: 'COUNT',
+      })
+      expect(firstCommand.input).not.toHaveProperty('FilterExpression')
+      expect(firstCommand.input.ExclusiveStartKey).toBeUndefined()
+
+      const secondCommand = queryCommands[1][0] as QueryCommand
+      expect(secondCommand.input.ExclusiveStartKey).toStrictEqual(lastEvaluatedKey)
+
+      const cappedCommand = queryCommands[2][0] as QueryCommand
+      expect(cappedCommand.input.Limit).toStrictEqual(2)
+
+      const latestMessageCommand = queryCommands[3][0] as QueryCommand
+      expect(latestMessageCommand.input).toMatchObject({
+        Limit: 1,
+        ProjectionExpression: 'messageId',
+        ScanIndexForward: false,
+        Select: 'SPECIFIC_ATTRIBUTES',
+      })
+
+      const recipientCommand = queryCommands[4][0] as QueryCommand
+      expect(recipientCommand.input).toMatchObject({
+        KeyConditionExpression: 'connectionId = :connectionId AND messageId <= :latestMessageId',
+        FilterExpression: 'contains(recipientDids, :recipientDid)',
+        ExpressionAttributeValues: {
+          ':recipientDid': { S: recipientDid },
+        },
+      })
+      expect(recipientCommand.input.Limit).toBeUndefined()
+    } finally {
+      send.mockRestore()
+    }
+  })
+
+  test('throws for a non-advancing pagination key', async () => {
+    const lastEvaluatedKey = {
+      connectionId: { S: connectionId },
+      messageId: { N: '2' },
+    }
+    let countQueryCount = 0
+    const send = vi.spyOn(DynamoDBClient.prototype, 'send').mockImplementation(async (command) => {
+      if (command instanceof CreateTableCommand) return {} as never
+      if (command instanceof DescribeTableCommand) return { Table: { TableStatus: 'ACTIVE' } } as never
+
+      countQueryCount += 1
+      return {
+        Count: 1,
+        LastEvaluatedKey: lastEvaluatedKey,
+      } as never
+    })
+
+    try {
+      const client = await DynamoDbClientRepository.initialize(clientOptions)
+
+      await expect(client.getMessageCount(connectionId)).rejects.toThrow('non-advancing pagination key')
+      expect(countQueryCount).toStrictEqual(2)
+    } finally {
+      send.mockRestore()
+    }
+  })
+
+  test('uses the configured pickup count ceiling without requiring a DI registration', async () => {
+    const send = vi.spyOn(DynamoDBClient.prototype, 'send').mockImplementation(async (command) => {
+      if (command instanceof CreateTableCommand) return {} as never
+      if (command instanceof DescribeTableCommand) return { Table: { TableStatus: 'ACTIVE' } } as never
+
+      return { Count: 2, LastEvaluatedKey: { connectionId: { S: connectionId } } } as never
+    })
+
+    try {
+      const repository = await DidCommTransportQueueDynamoDb.initialize({
+        ...clientOptions,
+        maximumMessageCount: 2,
+      })
+      const agentContext = new AgentContext({
+        contextCorrelationId: 'test',
+        dependencyManager: new DependencyManager(),
+      })
+
+      expect(await repository.getAvailableMessageCount(agentContext, { connectionId })).toStrictEqual(2)
+
+      const queryCommand = send.mock.calls.find(([command]) => command instanceof QueryCommand)?.[0] as QueryCommand
+      expect(queryCommand.input.Limit).toStrictEqual(2)
+    } finally {
+      send.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

This PR improves queued DIDComm message delivery by preventing duplicate delivery attempts and allowing unrelated Redis stream messages to be processed concurrently.

The changes are limited to the message-delivery path. No database schemas, queue formats, pickup protocols, or acknowledgement semantics are changed.

## Problem

With `QueueAndLiveModeDelivery`, Credo already:

1. Stores the forwarded message in the pickup queue.
2. Finds the local live-mode session.
3. Delivers messages from the queue.

However, storing the message also emits `DidCommMessageQueued`. The Redis listener handled this event by independently reading the same queue and delivering to the same session.

This allowed one forwarded message to trigger two competing delivery attempts:

- Credo’s built-in live delivery.
- The Redis queue-event delivery.

Redis stream entries were also processed sequentially, so a slow connection could delay unrelated connections in the same batch.

## Changes

### Prevent duplicate local delivery

Queue events emitted from Credo’s forward-message flow are now identified using an execution-scoped context.

When `QueueAndLiveModeDelivery` is enabled and a local session exists, Credo remains responsible for delivery and the Redis listener skips its duplicate attempt.

Only forward-message queue events are skipped. Messages queued by other parts of the application continue to use Redis-triggered delivery.

### Coordinate delivery per connection

Redis-triggered delivery now uses a per-connection single-flight coordinator.

It:

- Prevents concurrent queue drains for the same connection.
- Coalesces synchronous bursts into one queue drain.
- Schedules at most one follow-up drain when messages arrive during an active delivery.
- Allows different connections to be processed concurrently.
- Removes failed flights so later events can retry.

The follow-up drain prevents a message arriving during an active queue read from becoming stranded.

### Process Redis batches concurrently

Messages returned in the same Redis stream batch are now processed concurrently.

Concurrency remains bounded by the configured Redis batch size, which defaults to 10. The per-connection coordinator still prevents overlapping delivery for the same connection.

Each Redis entry is acknowledged only after its handler succeeds. One failed entry does not prevent successful entries in the same batch from being acknowledged.

## Behaviour

| Scenario | Behaviour |
|---|---|
| `QueueAndLiveModeDelivery` forward with a local session | Credo performs delivery; the duplicate Redis delivery is skipped |
| `QueueOnly` with a local session | Redis-triggered delivery uses the per-connection coordinator |
| Message queued outside the forward-message flow | Redis-triggered delivery remains enabled |
| Session belongs to another mediator instance | The message is sent to that instance through its Redis stream |
| No usable session or delivery fails | Existing push-notification fallback is used |
| `DirectDelivery` | Unchanged |

## Safety and compatibility

This PR does not change:

- Database schemas or indexes.
- DynamoDB, PostgreSQL, or Credo queue record formats.
- Message Pickup v1 or v2 protocol messages.
- Queue persistence or deletion behaviour.
- Redis consumer-group configuration.
- Redis acknowledgement requirements.
- Push-notification fallback behaviour.
- Direct-delivery behaviour.

Messages remain persisted before live delivery is attempted.

## Expected performance impact

This change should reduce:

- Duplicate queue reads.
- Competing WebSocket sends for the same connection.
- CPU and storage work caused by duplicate delivery attempts.
- Tail latency caused by unrelated connections waiting behind a slow Redis stream handler.

It also improves throughput across active connections without introducing unbounded concurrency.

## Testing

Added tests covering:

- Synchronous burst coalescing.
- Same-connection delivery serialization.
- Concurrent delivery across different connections.
- Recovery after a failed flight.
- Forward-delivery context isolation.
- Credo-versus-Redis ownership decisions.
- Concurrent Redis batch processing.
- Failure isolation and per-entry Redis acknowledgement.

Validation completed:

- `pnpm test --run` — 43/43 tests passed.
- `pnpm build` — all workspace packages built successfully.
- `pnpm types:check` — passed.
- Biome checks for changed files — passed.
- `git diff --check` — passed.